### PR TITLE
Support RiskIQ Illuminate Reputation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 ## Introduction
 
 This Python library provides an interface to the RiskIQ PassiveTotal Internet
-intelligence database. Security researchers and network defenders use 
-PassiveTotal to map threat actor infrastructure, profile hostnames & IP
-addresses, discover web technologies on Internet hosts.
+intelligence database and the RiskIQ Illuminate Reputation Score. 
+
+Security researchers and network defenders use RiskIQ PassiveTotal to map threat 
+actor infrastructure, profile hostnames & IP addresses, discover web technologies 
+on Internet hosts.
 
 Capabilites of this library include:
 * Credential management - protect API keys from accidental disclosure
@@ -25,7 +27,8 @@ To learn more about RiskIQ and start a free trial, visit [https://community.risk
 ## Getting Started
 
 ### Install the PassiveTotal Library
-The PassiveTotal Python library is availabe in pip under the package name `passivetotal`. Consider setting up a [virtual environment](https://docs.python.org/3/library/venv.html), then run:
+The PassiveTotal Python library is available in pip under the package name `passivetotal`. 
+Consider setting up a [virtual environment](https://docs.python.org/3/library/venv.html), then run:
 ```
 pip install passivetotal
 ```
@@ -45,7 +48,8 @@ an "API key". Look for an email address and use that value when prompted for you
 The "API Secret" is a long string of characters that should be kept secure. It is
 the primary authentication method for your API account. 
 
-Your PassiveTotal account may have a separate "API Secret" for your organization - when available, **always use your organization key** unless you have a specific reason not to.
+Your PassiveTotal account may have a separate "API Secret" for your organization - when 
+available, **always use your organization key** unless you have a specific reason not to.
 
 
 ### Build a Config File

--- a/README.md
+++ b/README.md
@@ -36,15 +36,16 @@ Queries to the API must be authenticated with a PassiveTotal API key.
 1. Log in (or sign up) at [community.riskiq.com](https://community.riskiq.com)
 2. Access your profile by clicking the person icon in the upper-right corner of the page.
 3. Click on "Account Settings"
-4. Under "API Access", click "Show" to reveal your user or organization credentials.
+4. Under "API Access", click "Show" to reveal your API credentials.
 
 The identifier for your API account is alternatively called a "username", a "user", or
 an "API key". Look for an email address and use that value when prompted for your 
 "API username".
 
 The "API Secret" is a long string of characters that should be kept secure. It is
-the primary authentication method for your API account. Note your PassiveTotal 
-account may have a seperate "API Secret" for your organization.
+the primary authentication method for your API account. 
+
+Your PassiveTotal account may have a separate "API Secret" for your organization - when available, **always use your organization key** unless you have a specific reason not to.
 
 
 ### Build a Config File

--- a/passivetotal/__init__.py
+++ b/passivetotal/__init__.py
@@ -13,3 +13,4 @@ from .libs.services import ServicesRequest
 from .libs.ssl import SslRequest
 from .libs.whois import WhoisRequest
 from .libs.generic import GenericRequest
+from .libs.illuminate import IlluminateRequest

--- a/passivetotal/analyzer/__init__.py
+++ b/passivetotal/analyzer/__init__.py
@@ -40,7 +40,8 @@ def init(**kwargs):
         (ProjectsRequest, 'Projects'), 
         (ServicesRequest, 'Services'),
         (SslRequest, 'SSL'), 
-        (WhoisRequest, 'Whois')
+        (WhoisRequest, 'Whois'),
+        (IlluminateRequest, 'Illuminate'),
     ]
     for c, name in api_classes:
         if 'username' in kwargs and 'api_key' in kwargs:

--- a/passivetotal/analyzer/_common.py
+++ b/passivetotal/analyzer/_common.py
@@ -78,6 +78,32 @@ class RecordList:
         sorted_results._records = sorted(self.all, key=lambda record: getattr(record, field), reverse=reverse)
         return sorted_results
 
+    def _ensure_firstlastseen(self):
+        """Ensure this record list has records of type FirstLastSeen."""
+        if not isinstance(self._records[0], FirstLastSeen):
+            raise TypeError('Cannot filter on a record type without firstseen / lastseen fields')
+    
+    def filter_dateseen_after(self, date_string):
+        self._ensure_firstlastseen()
+        dateobj = datetime.fromisoformat(date_string)
+        filtered_results = self._make_shallow_copy()
+        filtered_results._records = filter(lambda r: r.firstseen > dateobj, self._records)
+        return filtered_results
+
+    def filter_dateseen_before(self, date_string):
+        self._ensure_firstlastseen()
+        dateobj = datetime.fromisoformat(date_string)
+        filtered_results = self._make_shallow_copy()
+        filtered_results._records = filter(lambda r: r.lastseen < dateobj, self._records)
+        return filtered_results
+    
+    def filter_dateseen_between(self, start_date_string, end_date_string):
+        self._ensure_firstlastseen()
+        dateobj_start = datetime.fromisoformat(start_date_string)
+        dateobj_end = datetime.fromisoformat(end_date_string)
+        filtered_results = self._make_shallow_copy()
+        filtered_results._records = filter(lambda r: r.firstseen >= dateobj_start and r.lastseen <= dateobj_end, self._records)
+        return filtered_results
 
 
 class Record:

--- a/passivetotal/analyzer/hostname.py
+++ b/passivetotal/analyzer/hostname.py
@@ -54,6 +54,27 @@ class Hostname(HasComponents, HasCookies, HasTrackers, HasHostpairs, HasReputati
     def __repr__(self):
         return "Hostname('{}')".format(self.hostname)
     
+    def reset(self, prop=None):
+        """Reset this instance to clear all (default) or one cached properties.
+
+        Useful when changing module-level settings such as analyzer.set_date_range().
+
+        :param str prop: Property to reset (optional, if none provided all values will be cleared)
+        """
+        resettable_fields = ['whois','resolutions','summary','components',
+                             'cookies','trackers','pairs','reputation']
+        if not prop:
+            for field in resettable_fields:
+                setattr(self, '_'+field, None)
+            self._reset_hostpairs()
+        else:
+            if prop not in resettable_fields:
+                raise ValueError('Invalid property to reset')
+            if prop == 'pairs':
+                self._reset_hostpairs()
+            else:
+                setattr(self, '_'+prop, None)
+
     def get_host_identifier(self):
         """Alias for the hostname as a string.
         

--- a/passivetotal/analyzer/hostname.py
+++ b/passivetotal/analyzer/hostname.py
@@ -11,10 +11,11 @@ from passivetotal.analyzer.hostpairs import HasHostpairs
 from passivetotal.analyzer.cookies import HasCookies
 from passivetotal.analyzer.trackers import HasTrackers
 from passivetotal.analyzer.components import HasComponents
+from passivetotal.analyzer.illuminate import HasReputation
 
 
 
-class Hostname(HasComponents, HasCookies, HasTrackers, HasHostpairs):
+class Hostname(HasComponents, HasCookies, HasTrackers, HasHostpairs, HasReputation):
 
     """Represents a hostname such as api.passivetotal.org.
     
@@ -44,6 +45,7 @@ class Hostname(HasComponents, HasCookies, HasTrackers, HasHostpairs):
             self._pairs = {}
             self._pairs['parents'] = None
             self._pairs['children'] = None
+            self._reputation = None
         return self
     
     def __str__(self):

--- a/passivetotal/analyzer/hostpairs.py
+++ b/passivetotal/analyzer/hostpairs.py
@@ -11,9 +11,10 @@ class HostpairHistory(RecordList, PagedRecordList):
 
     """Historical connections between hosts."""
 
-    def __init__(self, api_response, direction=None):
+    def __init__(self, api_response=None, direction=None):
         self._direction = direction
-        self.parse(api_response)
+        if api_response:
+            self.parse(api_response)
 
     def _get_shallow_copy_fields(self):
         return ['_totalrecords','_direction']
@@ -114,6 +115,12 @@ class HostpairRecord(Record, FirstLastSeen):
 class HasHostpairs:
 
     """An object with hostpair history."""
+
+    def _reset_hostpairs(self):
+        """Reset the instance hostpairs private attributes."""
+        self._pairs = {}
+        self._pairs['parents'] = None
+        self._pairs['children'] = None
 
     def _api_get_hostpairs(self, direction, start_date=None, end_date=None):
         """Query the hostpairs API for the parent or child relationships.

--- a/passivetotal/analyzer/illuminate.py
+++ b/passivetotal/analyzer/illuminate.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+import pprint
+from functools import total_ordering
+from passivetotal.analyzer import get_api, get_config
+
+
+@total_ordering
+class ReputationScore:
+
+    """RiskIQ Illuminate Reputation profile for a hostname or an IP."""
+
+    def __init__(self, api_response):
+        self._response = api_response
+    
+    def __str__(self):
+        return '{0.score} ({0.classification})'.format(self)
+    
+    def __repr__(self):
+        return '<ReputationScore {0.score} "{0.classification}">'.format(self)
+    
+    def __int__(self):
+        return self.score
+    
+    def __gt__(self, other):
+        return self.score > other
+    
+    def __eq__(self, other):
+        return self.score == other
+
+    @property
+    def score(self):
+        """Reputation score as an integer ranging from 0-100.
+
+        Higher values indicate a greater likelihood of maliciousness.
+        """
+        return self._response.get('score')
+    
+    @property
+    def classification(self):
+        """Reputation classification as a string. 
+
+        Typical values include GOOD, SUSPICIOUS, MALICIOUS, or UNKNOWN.
+        """
+        return self._response.get('classification')
+    
+    @property
+    def rules(self):
+        """List of rules that informed the reputation score.
+
+        Returns a list of dictionaries.
+        """
+        return self._response.get('rules')
+
+
+
+class HasReputation:
+
+    """An object with a RiskIQ Illuminate Reputation score."""
+
+    def _api_get_reputation(self):
+        """Query the reputation endpoint."""
+
+        response = get_api('Illuminate').get_reputation(
+            query=self.get_host_identifier()
+        )
+        self._reputation = ReputationScore(response)
+        return self._reputation
+
+    @property
+    def reputation(self):
+        """RiskIQ Illuminate Reputation profile for a hostname or IP.
+
+        :rtype: :class:`passivetotal.analyzer.illuminate.ReputationScore`
+        """
+        if getattr(self, '_reputation'):
+            return self._reputation
+        return self._api_get_reputation()

--- a/passivetotal/analyzer/ip.py
+++ b/passivetotal/analyzer/ip.py
@@ -10,10 +10,11 @@ from passivetotal.analyzer.hostpairs import HasHostpairs
 from passivetotal.analyzer.cookies import HasCookies
 from passivetotal.analyzer.trackers import HasTrackers
 from passivetotal.analyzer.components import HasComponents
+from passivetotal.analyzer.illuminate import HasReputation
 
 
 
-class IPAddress(HasComponents, HasCookies, HasHostpairs, HasTrackers):
+class IPAddress(HasComponents, HasCookies, HasHostpairs, HasTrackers, HasReputation):
 
     """Represents an IPv4 address such as 8.8.8.8
     
@@ -43,6 +44,7 @@ class IPAddress(HasComponents, HasCookies, HasHostpairs, HasTrackers):
             self._pairs = {}
             self._pairs['parents'] = None
             self._pairs['children'] = None
+            self._reputation = None
         return self
 
     def __str__(self):

--- a/passivetotal/analyzer/ip.py
+++ b/passivetotal/analyzer/ip.py
@@ -53,6 +53,28 @@ class IPAddress(HasComponents, HasCookies, HasHostpairs, HasTrackers, HasReputat
     def __repr__(self):
         return "IPAddress('{}')".format(self.ip)
     
+    def reset(self, prop=None):
+        """Reset this instance to clear all (default) or one cached properties.
+
+        Useful when changing module-level settings such as analyzer.set_date_range().
+
+        :param str prop: Property to reset (optional, if none provided all values will be cleared)
+        """
+        resettable_fields = ['whois','resolutions','summary','components',
+                             'services','ssl_history',
+                             'cookies','trackers','pairs','reputation']
+        if not prop:
+            for field in resettable_fields:
+                setattr(self, '_'+field, None)
+            self._reset_hostpairs()
+        else:
+            if prop not in resettable_fields:
+                raise ValueError('Invalid property to reset')
+            if prop == 'pairs':
+                self._reset_hostpairs()
+            else:
+                setattr(self, '_'+prop, None)
+    
     def get_host_identifier(self):
         """Alias for the IP address as a string.
         

--- a/passivetotal/cli/info.py
+++ b/passivetotal/cli/info.py
@@ -5,7 +5,7 @@ __version__ = '1.0.0'
 
 import json
 import sys
-from passivetotal.api import Client
+from passivetotal import AccountClient
 from argparse import ArgumentParser
 
 
@@ -14,33 +14,26 @@ def main():
     subs = parser.add_subparsers(dest='cmd')
 
     account = subs.add_parser('account')
-    account.add_argument('--json', '-j', action="store_true",
-                         help="Output as JSON")
     sources = subs.add_parser('sources')
-    sources.add_argument('--json', '-j', action="store_true",
-                         help="Output as JSON")
     organization = subs.add_parser('organization')
-    organization.add_argument('--json', '-j', action="store_true",
-                              help="Output as JSON")
     args = parser.parse_args()
 
-    client = Client.from_config()
+    client = AccountClient.from_config()
     try:
         if args.cmd == 'account':
             data = client.get_account_details()
-        if args.cmd == 'sources':
+        elif args.cmd == 'sources':
             data = client.get_account_sources()
-        if args.cmd == 'organization':
+        elif args.cmd == 'organization':
             data = client.get_account_organization()
+        else:
+            data = parser.format_usage()
     except ValueError as e:
         parser.print_usage()
         sys.stderr.write('{}\n'.format(str(e)))
         sys.exit(1)
 
-    if args.json:
-        print(json.dumps(data, indent=4))
-    else:
-        print(data)
+    print(data)
 
 
 if __name__ == '__main__':

--- a/passivetotal/libs/illuminate.py
+++ b/passivetotal/libs/illuminate.py
@@ -1,0 +1,74 @@
+"""RiskIQ Illuminate API Interface."""
+
+from textwrap import TextWrapper
+from passivetotal.api import Client
+from passivetotal.response import Response
+from passivetotal.common import utilities
+
+
+
+class IlluminateRequest(Client):
+
+    """Client to interface with the RiskIQ Illuminate calls from the PassiveTotal API."""
+
+    def __init__(self, *args, **kwargs):
+        """Setup the primary client instance."""
+        super(IlluminateRequest, self).__init__(*args, **kwargs)
+
+    def get_reputation(self, **kwargs):
+        """Get RiskIQ Illuminate score for a domain or IP address.
+
+        Reference: 
+
+        :param query: Domain or IP address to search
+        :return: Dict of results
+        """
+        return self._get('reputation', '', **kwargs)
+
+
+
+class IlluminateReputationResponse(Response):
+
+    def _boost_properties(self):
+        pass
+    
+    @property
+    def csv(self):
+        fieldnames = ['host','score','classification']
+        if 'rules' in self._results[0]:
+            fieldnames.extend(['rule_names','rule_descriptions'])
+        data = []
+        for record in self._results:
+            row = [
+                record.get('host'),
+                record.get('score'),
+                record.get('classification')
+            ]
+            if 'rules' in record:
+                row.extend([
+                    '|'.join(['{0} (sev. {1})'.format(r.get('name'), r.get('severity')) for r in record.get('rules',[])]),
+                    '|'.join([r.get('description') for r in record.get('rules',[])]),
+                ])
+            data.append(row)
+        as_csv = utilities.to_csv(fieldnames, data)
+        return as_csv
+    
+    @property
+    def text(self):
+        wrapper = TextWrapper(width=60, initial_indent='      ', subsequent_indent='      ')
+        lines = []
+        width = max([len(r.get('host','')) for r in self._results])
+        for record in self._results:
+            template = '{host: <' + str(width) + '} {score:>3} ({c})'
+            lines.append(template.format(
+                host=record['host'],
+                score=record.get('score',''),
+                c=record.get('classification','')))
+            for rule in record.get('rules',[]):
+                lines.append('   {name} (severity {sev})'.format(
+                    name=rule.get('name'),
+                    sev=rule.get('severity')
+                ))
+                lines.extend(wrapper.wrap(rule.get('description')))
+        lines.append('')
+        return "\n".join(lines)

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ def read(fname):
 
 setup(
     name='passivetotal',
-    version='2.2.0',
-    description='Library for the RiskIQ PassiveTotal API',
+    version='2.3.0',
+    description='Library for the RiskIQ PassiveTotal and Illuminate API',
     url="https://github.com/passivetotal/python_api",
     author="RiskIQ",
     author_email="admin@passivetotal.org",

--- a/sphinx/illuminate.rst
+++ b/sphinx/illuminate.rst
@@ -42,11 +42,11 @@ property that returns an instance of a `ReputationScore` object. That
 object can be treated directly like a string or an integer, or you can 
 access the properties directly. 
 
-.. autoclass:: passivetotal.analyzer.illuminate.HasReputation
-    :members:
+.. autoclass:: passivetotal.analyzer.hostname.Hostname
+    :members: reputation
 
-.. autoclass:: passivetotal.analyzer.illuminate.ReputationScore
-    :members:
+.. autoclass:: passivetotal.analyzer.ip.IPAddress
+    :members: reputation
 
 
 Reputation Score CLI

--- a/sphinx/illuminate.rst
+++ b/sphinx/illuminate.rst
@@ -1,0 +1,106 @@
+RiskIQ Illuminate
+=================
+
+Reputation Scoring
+------------------
+
+The RiskIQ Illuminate platform provides dynamic reputation scoring on IPs
+and hostnames based on real-world activity, indicators, and behaviors.
+
+This library provides access to reptuation scores through the object analyzer
+(recommended), the command line interface, or  the low-level request wrappers.
+
+Review the :doc:`getting-started` guide for details on setting up your
+credentials and development environment.
+
+
+Hostname and IP Reputation Analysis
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code-block:: python
+    :linenos:
+
+    >>> from passivetotal import analyzer
+    >>> analyzer.init()
+    >>> reputation = analyzer.Hostname('2020-windows.com').reputation
+    >>> print(reputation)
+    72 (SUSPICIOUS)
+    >>> print(analyzer.IPAddress('123.213.1.23').reputation.score)
+    88
+    >>> analyzer.IPAddress('123.213.1.23').reputation.rules
+    [{'name': 'Third Party Blocklist (vo)',
+      'description': 'Threat Type: SERVICE SCANNER',
+      'severity': 5,
+      'link': None},
+     {'name': 'Open ports observed',
+      'description': 'The number of open ports may indicate maliciousness',
+      'severity': 3,
+     'link': None}]
+
+
+The ``Hostname`` and ``IPAddress`` analyzer objects provide a ``reputation`` 
+property that returns an instance of a `ReputationScore` object. That 
+object can be treated directly like a string or an integer, or you can 
+access the properties directly. 
+
+.. autoclass:: passivetotal.analyzer.illuminate.HasReputation
+    :members:
+
+.. autoclass:: passivetotal.analyzer.illuminate.ReputationScore
+    :members:
+
+
+Reputation Score CLI
+^^^^^^^^^^^^^^^^^^^^
+The ``pt-client`` command line script provides quick access to reputation profiles
+on one or more hosts in several formats. To get started, view the help for the 
+illuminate command:
+
+.. code-block:: console
+
+   (venv) % pt-client illuminate --help
+   usage: passivetotal illuminate [-h] [--reputation] [--format {json,csv,text}] [--brief] query [query ...]
+
+   positional arguments:
+   query                 One or more hostnames or IPs
+
+   optional arguments:
+   -h, --help            show this help message and exit
+   --reputation          Get hostname or IP reputation from RiskIQ Illuminate.
+   --format {json,csv,text}
+                           Format of the output from the query
+   --brief               Create a brief output; for reputation, prints score and classification only
+
+Use ``--reputation`` and pass a space-separated list of hostnames or IPs as the query parameter.
+
+The default format is "json" - for interactive use, try ``--format=text``:
+
+.. code-block:: console
+
+   (venv) % pt-client illuminate --reputation --format=text 2020-windows.com
+   2020-windows.com  72 (SUSPICIOUS)
+      Registrant email provider (severity 3)
+         Domain is registered with an email provider that is
+         more likely to register malicious domains
+      Registrar (severity 3)
+         Domains registered with this registrar are more likely
+         to be malicious
+
+The ``--brief`` option produces a more compact output with one result per line, which is also
+useful with the ``--format=csv`` parameter to prepare a compact dataset for import into another
+product. 
+
+Pass multiple hostnames or IPs at the end of the command (separated by spaces) to
+analyze multiple hosts at one time.
+
+
+
+Reputation Request Wrapper
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use the low-level ``Illuminate`` request wrapper for direct queries to the
+API.
+
+.. autoclass:: passivetotal.libs.illuminate.IlluminateRequest
+    :members: get_reputation
+
+

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -20,6 +20,7 @@ Contents:
    getting-started
    analyzer
    wrappers
+   illuminate
 
 
 Indices and tables

--- a/sphinx/wrappers.rst
+++ b/sphinx/wrappers.rst
@@ -79,6 +79,12 @@ Projects Request
     :members:
     :show-inheritance:
 
+Illuminate Request
+------------------
+.. autoclass:: passivetotal.libs.illuminate.IlluminateRequest
+    :members:
+    :show-inheritance:
+
 Services Request
 ----------------
 .. autoclass:: passivetotal.libs.services.ServicesRequest


### PR DESCRIPTION
Adds support for the RiskIQ Illuminate Reputation API, including analyzer objects, CLI and request wrappers. New docs for Illuminate capabilities. A few bug fixes and corrections to README docs.