### PR TITLE
v2.4.1 - as_dict and projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v2.4.1
+
+#### Enhancements:
+
+- Added an `as_dict` property across all Analyzer objects to simplify integration
+  with other systems. Returns a dictionary representation of the object or the list.
+- New `projects` attribute on IPAddress and Hostname objects returns list of projects
+  that contain that host as an artifact. 
+- New `analyzer.set_project()` method on the Analyzer module to set an active project
+  by name or guid, and new `add_to_project()` methods on Analyzer objects to quickly
+  add the object to the active project.
+- Direct methods on new `Project` and `Artifact` objects to directly manipulate monitoring
+  status and tags.
+
+
+#### Bug Fixes:
+
+- Added missing ArtifactsRequest to package-level imports
+
+
+
 ## v2.4.0
 
 #### Enhancements:

--- a/passivetotal/__init__.py
+++ b/passivetotal/__init__.py
@@ -2,6 +2,7 @@ from .libs.account import AccountClient
 from .libs.actions import ActionsClient
 from .libs.articles import ArticlesRequest
 from .libs.attributes import AttributeRequest
+from .libs.artifacts import ArtifactsRequest
 from .libs.cards import CardsRequest
 from .libs.cookies import CookiesRequest
 from .libs.dns import DnsRequest

--- a/passivetotal/analyzer/__init__.py
+++ b/passivetotal/analyzer/__init__.py
@@ -17,6 +17,9 @@ config = {
     'pprint': { 'indent': 2 },
     'datesort': None,
     'dateorder': None,
+    'project_name': None,
+    'project_visiblity': 'analyzer',
+    'project_guid': None
 }
 
 
@@ -43,6 +46,9 @@ def init(**kwargs):
         (SslRequest, 'SSL'), 
         (WhoisRequest, 'Whois'),
         (IlluminateRequest, 'Illuminate'),
+        (ArticlesRequest, 'Articles'),
+        (ProjectsRequest, 'Projects'),
+        (ArtifactsRequest, 'Artifacts'),
     ]
     for c, name in api_classes:
         if 'username' in kwargs and 'api_key' in kwargs:
@@ -149,6 +155,36 @@ def set_dateorder_descending():
     cookies, hostpairs, and trackers.
     """
     config['dateorder'] = 'desc'
+
+def set_project(name_or_guid, visibility='analyst', description='', tags=None, create_if_missing=True):
+    """Set the active Illuminate Project for this investigation. 
+
+    Used by Analyzer objects to persist results to projects. Performs an API query to determine if project
+    exists, create it if it is missing, and obtain necessary details.
+
+    :param name_or_guid: Project name or project GUID.
+    :param visibility: Who can see the project: public, private or analyst (optional, defaults to 'analyst').
+    :param description: Description of the project (optional).
+    :param tags: List of tags to apply to the project (optional).
+    :param create_if_missing: Whether to auto-create the project if it doesn't exist (optional, defaults to true)."""
+    projreq = get_api('Projects')
+    projects = projreq.find_projects(name_or_guid, visibility)
+    if len(projects) == 0:
+        if projreq.is_guid(name_or_guid):
+            raise AnalyzerError('No project found with that GUID')
+        if create_if_missing:
+            result = projreq.create_project(name_or_guid, visibility, description=description, tags=tags)
+            config['project_name'] = name_or_guid
+            config['project_guid'] = result['guid']
+            config['project_visibility'] = visibility
+        else:
+            raise AnalyzerError('Project does not exist and create_if_missing is False.')
+    elif len(projects) == 1:
+        config['project_name'] = projects[0]['name']
+        config['project_guid'] = projects[0]['guid']
+        config['project_visibility'] = projects[0]['visibility']
+    else:
+        raise AnalyzerError('More than one project found; narrow the search criteria or use a unique name')
 
 
 from passivetotal.analyzer.hostname import Hostname

--- a/passivetotal/analyzer/__init__.py
+++ b/passivetotal/analyzer/__init__.py
@@ -157,7 +157,10 @@ def set_dateorder_descending():
     config['dateorder'] = 'desc'
 
 def get_project():
-    """Get the active project."""
+    """Get the active project.
+    
+    :rtype: :class:`passivetotal.analyzer.projects.Project` 
+    """
     if config['project_guid'] is None:
         return None
     return Project.find(config['project_guid'])

--- a/passivetotal/analyzer/__init__.py
+++ b/passivetotal/analyzer/__init__.py
@@ -156,6 +156,12 @@ def set_dateorder_descending():
     """
     config['dateorder'] = 'desc'
 
+def get_project():
+    """Get the active project."""
+    if config['project_guid'] is None:
+        return None
+    return Project.find(config['project_guid'])
+
 def set_project(name_or_guid, visibility='analyst', description='', tags=None, create_if_missing=True):
     """Set the active Illuminate Project for this investigation. 
 
@@ -191,3 +197,4 @@ from passivetotal.analyzer.hostname import Hostname
 from passivetotal.analyzer.ip import IPAddress
 from passivetotal.analyzer.ssl import CertificateField
 from passivetotal.analyzer.articles import AllArticles
+from passivetotal.analyzer.projects import Project, ProjectList

--- a/passivetotal/analyzer/articles.py
+++ b/passivetotal/analyzer/articles.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from passivetotal.analyzer._common import (
-    RecordList, Record, FirstLastSeen
+    RecordList, Record
 )
 from passivetotal.analyzer import get_api
 
@@ -18,12 +18,20 @@ class ArticlesList(RecordList):
     def _get_sortable_fields(self):
         return ['age','title','type']
     
+    def _get_dict_fields(self):
+        return ['totalrecords']
+    
+    @property
+    def totalrecords(self):
+        return self._totalrecords
+    
     def parse(self, api_response):
         """Parse an API response."""
         self._totalrecords = api_response.get('totalRecords')
         self._records = []
-        for article in api_response.get('articles', []):
-            self._records.append(Article(article))
+        if api_response.get('articles', None) is not None:
+            for article in api_response.get('articles', []):
+                self._records.append(Article(article))
     
     def filter_tags(self, tags):
         """Filtered article list that includes articles with an exact match to one
@@ -109,6 +117,11 @@ class Article(Record):
         self._categories = response.get('categories')
         self._indicators = response.get('indicators')
 
+    def _get_dict_fields(self):
+        return ['guid','title','type','summary','str:date_published','age',
+                 'link','categories','tags','indicators','indicator_count',
+                 'indicator_types','str:ips','str:hostnames']
+
     def _ensure_details(self):
         """Ensure we have details for this article.
 
@@ -158,7 +171,7 @@ class Article(Record):
                 if text.casefold() in tag.casefold():
                     return True
         return False
-    
+   
     @property
     def guid(self):
         """Article unique ID within the RiskIQ system."""

--- a/passivetotal/analyzer/components.py
+++ b/passivetotal/analyzer/components.py
@@ -23,6 +23,9 @@ class ComponentHistory(RecordList, PagedRecordList):
     def _get_sortable_fields(self):
         return ['firstseen','lastseen','category','label','hostname']
     
+    def _get_dict_fields(self):
+        return ['totalrecords']
+    
     def parse(self, api_response):
         """Parse an API response."""
         self._totalrecords = api_response.get('totalRecords')
@@ -30,6 +33,15 @@ class ComponentHistory(RecordList, PagedRecordList):
         for result in api_response.get('results', []):
             self._records.append(ComponentRecord(result))
     
+    @property
+    def as_dict(self):
+        d = super().as_dict
+        d.update({
+            'distinct_hostnames': [ str(h) for h in self.hostnames ],
+            'distinct_categories': [ cat for cat in self.categories ],
+            'distinct_values': [ val for val in self.values ],
+        })
+        return d
 
     @property
     def hostnames(self):
@@ -70,15 +82,8 @@ class ComponentRecord(Record, FirstLastSeen):
     def __repr__(self):
         return '<ComponentRecord "{0.label}">'.format(self)
 
-    @property
-    def as_dict(self):
-        """Component data as a mapping."""
-        return {
-            field: getattr(self, field) for field in [
-                'firstseen','lastseen','version','category',
-                'label','hostname'
-            ]
-        }
+    def _get_dict_fields(self):
+        return ['category','str:firstseen','str:lastseen','label','version','str:hostname']
     
     @property
     def category(self):

--- a/passivetotal/analyzer/cookies.py
+++ b/passivetotal/analyzer/cookies.py
@@ -17,12 +17,24 @@ class CookieHistory(RecordList, PagedRecordList):
     def _get_sortable_fields(self):
         return ['firstseen','lastseen','name','domain']
     
+    def _get_dict_fields(self):
+        return ['totalrecords']
+    
     def parse(self, api_response):
         """Parse an API response."""
         self._totalrecords = api_response.get('totalRecords')
         self._records = []
         for result in api_response.get('results', []):
             self._records.append(CookieRecord(result))
+    
+    @property
+    def as_dict(self):
+        d = super().as_dict
+        d.update({
+            'distinct_domains': self.domains,
+            'distinct_names': self.names,
+        })
+        return d
     
     @property
     def domains(self):
@@ -53,14 +65,8 @@ class CookieRecord(Record, FirstLastSeen):
     def __repr__(self):
         return '<CookieRecord {0.name}>'.format(self)
 
-    @property
-    def as_dict(self):
-        """Component data as a mapping."""
-        return {
-            field: getattr(self, field) for field in [
-                'firstseen','lastseen','domain','name','hostname'
-            ]
-        }
+    def _get_dict_fields(self):
+        return ['domain','str:firstseen','str:lastseen','name','hostname']
     
     @property
     def domain(self):

--- a/passivetotal/analyzer/enrich.py
+++ b/passivetotal/analyzer/enrich.py
@@ -1,10 +1,12 @@
 from datetime import date
 from passivetotal.analyzer import get_api
-from passivetotal.analyzer._common import Record, RecordList, PrettyList, PrettyRecord, AnalyzerError
+from passivetotal.analyzer._common import (
+    Record, RecordList, AnalyzerError
+)
 
 
 
-class MalwareList(RecordList, PrettyList):
+class MalwareList(RecordList):
 
     """List of malware hashes associated with a host or domain."""
 
@@ -26,7 +28,7 @@ class MalwareList(RecordList, PrettyList):
 
 
 
-class MalwareRecord(Record, PrettyRecord):
+class MalwareRecord(Record):
 
     """Record of malware associated with a host."""
 
@@ -42,14 +44,8 @@ class MalwareRecord(Record, PrettyRecord):
     def __repr__(self):
         return "<MalwareRecord {0.hash}>".format(self)
     
-    @property
-    def as_dict(self):
-        """Malware record as a Python dictionary."""
-        return {
-            field: getattr(self, field) for field in [
-                'hash','source','source_url','date_collected'
-            ]
-        }
+    def _get_dict_fields(self):
+        return ['hash','source','source_url','str:date_collected']
     
     @property
     def hash(self):

--- a/passivetotal/analyzer/hostname.py
+++ b/passivetotal/analyzer/hostname.py
@@ -15,12 +15,13 @@ from passivetotal.analyzer.components import HasComponents
 from passivetotal.analyzer.illuminate import HasReputation
 from passivetotal.analyzer.articles import HasArticles
 from passivetotal.analyzer.enrich import HasMalware
+from passivetotal.analyzer.projects import IsArtifact
 
 
 
 class Hostname(HasComponents, HasCookies, HasTrackers, HasHostpairs, 
                HasReputation, HasArticles, HasResolutions, HasSummary,
-               HasMalware):
+               HasMalware, IsArtifact):
 
     """Represents a hostname such as api.passivetotal.org.
     

--- a/passivetotal/analyzer/illuminate.py
+++ b/passivetotal/analyzer/illuminate.py
@@ -2,10 +2,11 @@ from datetime import datetime
 import pprint
 from functools import total_ordering
 from passivetotal.analyzer import get_api, get_config
+from passivetotal.analyzer._common import AsDictionary
 
 
 @total_ordering
-class ReputationScore:
+class ReputationScore(AsDictionary):
 
     """RiskIQ Illuminate Reputation profile for a hostname or an IP."""
 
@@ -26,6 +27,15 @@ class ReputationScore:
     
     def __eq__(self, other):
         return self.score == other
+    
+    @property
+    def as_dict(self):
+        """Representation as a dictionary object."""
+        return {
+            'score': self.score,
+            'classification': self.classification,
+            'rules': self.rules,
+        }
 
     @property
     def score(self):

--- a/passivetotal/analyzer/ip.py
+++ b/passivetotal/analyzer/ip.py
@@ -3,6 +3,7 @@
 
 from passivetotal.analyzer import get_api, get_config
 from passivetotal.analyzer._common import is_ip, AnalyzerError
+from passivetotal.analyzer.whois import IPWhois
 from passivetotal.analyzer.pdns import HasResolutions
 from passivetotal.analyzer.services import Services
 from passivetotal.analyzer.ssl import Certificates
@@ -101,7 +102,8 @@ class IPAddress(HasComponents, HasCookies, HasHostpairs, HasTrackers,
 
     def _api_get_whois(self):
         """Query the pDNS API for resolution history."""
-        self._whois = get_api('Whois').get_whois_details(query=self._ip)
+        response = get_api('Whois').get_whois_details(query=self._ip)
+        self._whois = IPWhois(response)
         return self._whois
     
     @property
@@ -124,9 +126,13 @@ class IPAddress(HasComponents, HasCookies, HasHostpairs, HasTrackers,
             return self._services
         return self._api_get_services()
     
+    
     @property
     def whois(self):
-        """Whois record details for this IP."""
+        """Most recently available Whois record for IP.
+
+        :rtype: :class:`passivetotal.analyzer.whois.IPWhois`
+        """
         if getattr(self, '_whois', None) is not None:
             return self._whois
         return self._api_get_whois()

--- a/passivetotal/analyzer/ip.py
+++ b/passivetotal/analyzer/ip.py
@@ -15,12 +15,13 @@ from passivetotal.analyzer.components import HasComponents
 from passivetotal.analyzer.illuminate import HasReputation
 from passivetotal.analyzer.articles import HasArticles
 from passivetotal.analyzer.enrich import HasMalware
+from passivetotal.analyzer.projects import IsArtifact
 
 
 
 class IPAddress(HasComponents, HasCookies, HasHostpairs, HasTrackers, 
                 HasReputation, HasArticles, HasResolutions, HasSummary,
-                HasMalware):
+                HasMalware, IsArtifact):
 
     """Represents an IPv4 address such as 8.8.8.8
     

--- a/passivetotal/analyzer/projects.py
+++ b/passivetotal/analyzer/projects.py
@@ -71,7 +71,7 @@ class Project(Record):
         return self.name
     
     def __repr__(self):
-        return f"<Project {self.guid} '{self.name}'"
+        return "<Project {0.guid} '{0.name}'".format(self)
 
     def _get_dict_fields(self):
         return ['project_guid','name','description','visibility','is_featured',
@@ -260,7 +260,7 @@ class Artifact(Record):
         return self.name
 
     def __repr__(self):
-        return f"<Artifact {self.guid} '{self.name}'>"
+        return "<Artifact {0.guid} '{0.name}'>".format(self)
 
     def _get_dict_fields(self):
         return ['type','project_guid','artifact_guid','is_monitored',

--- a/passivetotal/analyzer/projects.py
+++ b/passivetotal/analyzer/projects.py
@@ -1,0 +1,389 @@
+from datetime import datetime
+from passivetotal.analyzer import get_api, get_config, get_object
+from passivetotal.analyzer._common import RecordList, Record, AnalyzerError
+
+
+class ProjectList(RecordList):
+    """List of Projects with artifacts."""
+    
+    def _get_shallow_copy_fields(self):
+        return []
+
+    def _get_sortable_fields(self):
+        pass
+
+    def _get_dict_fields(self):
+        return []
+    
+    def parse(self, api_response):
+        """Parse an API response."""
+        self._records = []
+        for project in api_response:
+            self._records.append(Project(project))
+
+
+
+class Project(Record):
+
+    """Project record with collection of artifacts."""
+
+    def __init__(self, api_response):
+        self._guid = api_response['guid']
+        self._active = api_response['active']
+        self._name = api_response['name']
+        self._description = api_response['description']
+        self._visiblity = api_response['visibility']
+        self._featured = api_response['featured']
+        self._tags = api_response['tags']
+        self._owner = api_response['owner']
+        self._creator = api_response['creator']
+        self._created = api_response['created']
+        self._organization = api_response['organization']
+        self._collaborators = api_response['collaborators']
+        self._link = api_response['link']
+        self._links = api_response['links']
+        self._subscribers = api_response['subscribers']
+        self._can_edit = api_response['can_edit']
+
+    def __str__(self):
+        return self.name
+    
+    def __repr__(self):
+        return f"<Project {self.guid} '{self.name}'"
+
+    def _get_dict_fields(self):
+        return ['project_guid','name','description','visibility','is_featured',
+                'tags','owner','creator','str:created','organization','link',
+                'collaborators','links','subscribers','can_edit']
+    
+    @property
+    def guid(self):
+        """Alias for project_guid; project's unique identifier."""
+        return self._guid
+    
+    @property
+    def project_guid(self):
+        """Project unique identifier."""
+        return self._guid
+    
+    @property
+    def name(self):
+        """Name of the project."""
+        return self._name
+    
+    @property
+    def description(self):
+        """Description of the project."""
+        return self._description
+    
+    @property
+    def visibility(self):
+        """Visiblity of the project."""
+        return self._visiblity
+    
+    @property
+    def is_featured(self):
+        """Whether this is a featured project."""
+        return self._featured
+    
+    @property
+    def tags(self):
+        """List of tags associated with this project."""
+        return self._tags
+    
+    @property
+    def owner(self):
+        """Owner of the project."""
+        return self._owner
+    
+    @property
+    def creator(self):
+        """User ID of the project creator."""
+        return self._creator
+    
+    @property
+    def created(self):
+        """Date this project was created."""
+        return datetime.fromisoformat(self._created)
+    
+    @property
+    def organization(self):
+        """Organization this project is connected to."""
+        return self._organization
+    
+    @property
+    def collaborators(self):
+        """List of user IDs collaborating on this project."""
+        return self._collaborators
+    
+    @property
+    def link(self):
+        """Project link."""
+        return self._link
+    
+    @property
+    def links(self):
+        """Dictionary of various links to this project in the UI."""
+        return self._links
+    
+    @property
+    def subscribers(self):
+        """List of users who receive notifcations about artifacts in this project."""
+        return self._subscribers
+    
+    @property
+    def can_edit(self):
+        """Whether the project can be edited."""
+        return self._can_edit
+    
+
+
+class ArtifactList(RecordList):
+
+    """List of artifact entries."""
+
+    def _get_shallow_copy_fields(self):
+        return []
+
+    def _get_sortable_fields(self):
+        return []
+
+    def _get_dict_fields(self):
+        return []
+    
+    def parse(self, api_response):
+        """Parse an API response."""
+        self._records = []
+        if 'message' in api_response: # none found
+            return
+        if 'guid' in api_response: # one record
+            self._records.append(Artifact(api_response))
+        else:
+            self._records.extend([ Artifact(a) for a in api_response['artifacts']])
+
+
+
+class Artifact(Record):
+
+    """An artifact in a project."""
+
+    def __init__(self, api_response):
+        self._type = api_response.get('type')
+        self._project_guid = api_response.get('project')
+        self._artifact_guid = api_response.get('guid')
+        self._monitor = api_response.get('monitor')
+        self._monitorable = api_response.get('monitorable')
+        self._organization = api_response.get('organization')
+        self._links = api_response.get('links')
+        self._owner = api_response.get('owner')
+        self._query = api_response.get('query')
+        self._creator = api_response.get('creator')
+        self._created = api_response.get('created')
+        self._tags_meta = api_response.get('tag_meta')
+        self._tags_global = api_response.get('global_tags')
+        self._tags_system = api_response.get('system_tags')
+        self._tags_user = api_response.get('user_tags')
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return f"<Artifact {self.guid} '{self.name}'>"
+
+    def _get_dict_fields(self):
+        return ['type','project_guid','artifact_guid','is_monitored',
+                'is_monitorable','organization','links','owner','name','creator',
+                'tags_meta','tags_global','tags_system','tags_user','str:created']
+
+    def delete(self):
+        """Delete this artifact record.
+        
+        :rtype bool: Whether the deletion was successful.
+        """
+        result = get_api('Artifacts').delete_artifact(self.guid)
+        if 'message' in result:
+            raise AnalyzerError('Cannot delete artifact: {}'.format(result['message']))
+        else:
+            return True
+    
+    def enable_monitoring(self):
+        """Activate monitoring on this artifact.
+
+        :rtype bool: Whether monitoring was activated successfully.
+        """
+        if self.is_monitored:
+            return True
+        result = get_api('Artifacts').update_artifact(self.guid, monitor=True)
+        if 'message' in result:
+            raise AnalyzerError('Cannot set monitoring: {}'.format(result['message']))
+        self._monitor = result['monitor']
+        return self._monitor
+    
+    def disable_monitoring(self):
+        """Deactivate monitoring on this artifact.
+
+        :rtype bool: Whether monitoring was deactivated successfully.
+        """
+        if not self.is_monitored:
+            return True
+        result = get_api('Artifacts').update_artifact(self.guid, monitor=False)
+        if 'message' in result:
+            raise AnalyzerError('Cannot set monitoring: {}'.format(result['message']))
+        self._monitor = result['monitor']
+        return not self._monitor
+    
+    def update_tags(self, new_tags):
+        """Set a new list of tags on this artifact.
+
+        The new tag list will overwrite the existing tag list.
+        :rtype bool: Whether tags were updated successfully.
+        """
+        if type(new_tags) is str:
+            tags = new_tags.split(',')
+        else:
+            tags = new_tags
+        result = get_api('Artifacts').update_artifact(self.guid, tags=tags)
+        if 'message' in result:
+            raise AnalyzerError('Cannot set tags: {}'.format(result['message']))
+        self._tags_user = result['user_tags']
+        return True
+
+    @property
+    def type(self):
+        """Type of the artifact (IP, domain, hash, etc.)"""
+        return self._type
+    
+    @property
+    def project_guid(self):
+        """Unique ID of the project that contains this artifact."""
+        return self._project_guid
+    
+    @property
+    def artifact_guid(self):
+        """Unique ID of the artifact."""
+        return self._artifact_guid
+    
+    @property
+    def guid(self):
+        """Unique ID of the artifact; alias of artifact_guid."""
+        return self.artifact_guid
+    
+    @property
+    def is_monitored(self):
+        """Whether the artifact is actively being monitored."""
+        return self._monitor
+    
+    @property
+    def is_monitorable(self):
+        """Whether the artifact can be monitored."""
+        return self._monitorable
+    
+    @property
+    def organization(self):
+        """Organization that owns the artifact record."""
+        return self._organization
+    
+    @property
+    def links(self):
+        """Dictionary of various link types to get more details in the UI."""
+        return self._links
+    
+    @property
+    def owner(self):
+        """User or organization that owns the artifact record."""
+        return self._owner
+    
+    @property
+    def name(self):
+        """Name of the artifact (the actual ip, domain, hash, etc.)"""
+        return self._query
+    
+    @property
+    def creator(self):
+        """User ID that created the artifact."""
+        return self._creator
+    
+    @property
+    def created(self):
+        """Date the artifact was created."""
+        return datetime.fromisoformat(self._created)
+    
+    @property
+    def tags_meta(self):
+        """Descriptive data about the tags on this artifact."""
+        return self._tags_meta
+    
+    @property
+    def tags_system(self):
+        """List of system tags for this artifact."""
+        return self._tags_system
+    
+    @property
+    def tags_global(self):
+        """List of global tags for this artifact."""
+        return self._tags_global
+    
+    @property
+    def tags_user(self):
+        """List of user-defined tags for this artifact."""
+        return self._tags_user
+    
+    @property
+    def hostname(self):
+        """Hostname object for this artifact, if artifact type is domain."""
+        if self.type == 'domain':
+            return  get_object(self.name)
+        else:
+            return None
+    
+    @property
+    def ip(self):
+        """IPAddress object for this artifact, if artifact type is IP."""
+        if self.type == 'ip':
+            return get_object(self.name)
+        else:
+            return None
+
+
+
+class IsArtifact:
+    """An object that can be an artifact in an Illuminate project."""
+
+    def _api_get_projects(self):
+        """Query the artifacts and projects API for projects that include this object."""
+        projects = []
+        for artifact in self.artifacts:
+            projects.extend(get_api('Projects').find_projects(artifact.project_guid))
+        self._projects = ProjectList(projects)
+        return self._projects
+        
+
+    def _api_get_artifacts(self):
+        """Query the artifacts API to find project artifacts that match this object."""
+        response = get_api('Artifacts').get_artifacts(query=self.get_host_identifier())
+        self._artifacts = ArtifactList(response)
+        return self._artifacts
+
+    @property
+    def projects(self):
+        if getattr(self, '_projects', None) is not None:
+            return self._projects
+        return self._api_get_projects()
+    
+    @property
+    def artifacts(self):
+        if getattr(self, '_artifacts', None) is not None:
+            return self._artifacts
+        return self._api_get_artifacts()
+    
+    def save_to_project(self, artifact_tags=None):
+        """Save this object to the active project as an artifact.
+
+        Before saving the object, call `analyzer.set_project()` to set or create
+        the active project.
+
+        :param project_tags: List of tags to apply to the artifact, optional. """
+        project_guid = get_config('project_guid')
+        if project_guid is None:
+            raise AnalyzerError('Project is not set; call analyzer.set_project() to get started.')
+        get_api('Artifacts').upsert_artifact(project_guid, self.get_host_identifier(), tags=artifact_tags)

--- a/passivetotal/analyzer/projects.py
+++ b/passivetotal/analyzer/projects.py
@@ -113,6 +113,10 @@ class Project(Record):
 
     @property
     def artifacts(self):
+        """List of artifacts in this project.
+
+        :rtype: :class:`passivetotal.analyzer.projects.ArtifactList` 
+        """
         if getattr(self, '_artifacts', None) is not None:
             return self._artifacts
         return self._api_get_artifacts()
@@ -438,12 +442,20 @@ class IsArtifact:
 
     @property
     def projects(self):
+        """List of projects that reference this object as an artifact.
+        
+        :rtype: :class:`passivetotal.analyzer.projects.ProjectList` 
+        """
         if getattr(self, '_projects', None) is not None:
             return self._projects
         return self._api_get_projects()
     
     @property
     def artifacts(self):
+        """List of project artifacts that correspond with this object.
+        
+        :rtype: :class:`passivetotal.analyzer.projects.ArtifactList` 
+        """
         if getattr(self, '_artifacts', None) is not None:
             return self._artifacts
         return self._api_get_artifacts()

--- a/passivetotal/analyzer/services.py
+++ b/passivetotal/analyzer/services.py
@@ -1,10 +1,10 @@
 from datetime import datetime
-from passivetotal.analyzer._common import RecordList, Record, PrettyRecord, PrettyList, FirstLastSeen
+from passivetotal.analyzer._common import RecordList, Record, FirstLastSeen
 from passivetotal.analyzer.ssl import CertHistoryRecord
 from passivetotal.analyzer import get_api
 
 
-class Services(RecordList, PrettyList):
+class Services(RecordList):
 
     """Historical port, service and banner data."""
 
@@ -12,7 +12,10 @@ class Services(RecordList, PrettyList):
         return ['_totalrecords']
     
     def _get_sortable_fields(self):
-        return ['firstseen','lastseen','duration','port','count','status','protocol']
+        return ['str:firstseen','str:lastseen','duration','port','count','status','protocol']
+    
+    def _get_dict_fields(self):
+        return ['totalrecords']
     
     def parse(self, api_response):
         """Parse an API response."""
@@ -52,7 +55,7 @@ class Services(RecordList, PrettyList):
     
 
 
-class ServiceRecord(Record, FirstLastSeen, PrettyRecord):
+class ServiceRecord(Record, FirstLastSeen):
 
     """Record of an observed port with current and recent services."""
 
@@ -74,16 +77,10 @@ class ServiceRecord(Record, FirstLastSeen, PrettyRecord):
     def __repr__(self):
         return "<ServiceRecord {0.protocol} {0.port}>".format(self)
 
-    @property
-    def as_dict(self):
-        """Services data as a mapping."""
-        return {
-            field: getattr(self, field) for field in [
-                'port','count','status','protocol','banners',
-                'current_services','recent_services', 'firstseen',
-                'lastseen'
-            ]
-        }
+    def _get_dict_fields(self):
+        return ['port','count','status','protocol','banners',
+                'current_services','recent_services', 'str:firstseen',
+                'str:lastseen']
 
     @property
     def port(self):

--- a/passivetotal/analyzer/ssl.py
+++ b/passivetotal/analyzer/ssl.py
@@ -166,6 +166,11 @@ class CertificateRecord(Record, FirstLastSeen):
         self._ip_history = response['results'][0]
         return self._ip_history
     
+    def _get_dict_fields(self):
+        fields = self.__class__._fields
+        fields.extend(['days_valid','expired'])
+        return fields
+    
     @property
     def iphistory(self):
         """Get the direct API response for a history query on this certificates hash.
@@ -191,17 +196,6 @@ class CertificateRecord(Record, FirstLastSeen):
             except AnalyzerError:
                 continue
         return ips
-
-    @property
-    def as_dict(self):
-        """All SSL fields as a mapping with string values."""
-        return { field: getattr(self, field).value for field in self.__class__._fields }
-    
-    @property
-    def pretty(self):
-        """Pretty-print formatted view of all SSL fields."""
-        config = get_config('pprint')
-        return pprint.pformat(self.as_dict, **config)
 
     @property
     def hash(self):
@@ -235,6 +229,8 @@ class CertificateRecord(Record, FirstLastSeen):
         
         :rtype: datetime
         """
+        if self.issuerDate.value is None:
+            return None
         return datetime.strptime(self.issuerDate.value, '%b %d %H:%M:%S %Y %Z')
     
     @property
@@ -244,6 +240,8 @@ class CertificateRecord(Record, FirstLastSeen):
         Returns the timedelta between date_expires and date_issued.
         :rtype: int
         """
+        if self.date_expires is None or self.date_issued is None:
+            return None
         interval = self.date_expires - self.date_issued
         return interval.days
     
@@ -437,6 +435,8 @@ class CertificateRecord(Record, FirstLastSeen):
         
         :rtype: datetime
         """
+        if self.expirationDate.value is None:
+            return None
         return datetime.strptime(self.expirationDate.value, '%b %d %H:%M:%S %Y %Z')
     
     @property
@@ -445,6 +445,8 @@ class CertificateRecord(Record, FirstLastSeen):
         
         :rtype: bool
         """
+        if self.date_expires is None:
+            return None
         return datetime.utcnow() > self.date_expires
     
     @property

--- a/passivetotal/analyzer/trackers.py
+++ b/passivetotal/analyzer/trackers.py
@@ -17,6 +17,19 @@ class TrackerHistory(RecordList, PagedRecordList):
     def _get_sortable_fields(self):
         return ['firstseen','lastseen','category','label','hostname']
     
+    def _get_dict_fields(self):
+        return ['totalrecords']
+    
+    @property
+    def as_dict(self):
+        d = super().as_dict
+        d.update({
+            'distinct_hostnames': [ str(host) for host in self.hostnames ],
+            'distinct_categories': self.categories,
+            'distinct_values': self.values
+        })
+        return d
+    
     def parse(self, api_response):
         """Parse an API response."""
         self._totalrecords = api_response.get('totalRecords')
@@ -59,16 +72,9 @@ class TrackerRecord(Record, FirstLastSeen):
     
     def __repr__(self):
         return '<ComponentRecord "{0.value}">'.format(self)
-
-    @property
-    def as_dict(self):
-        """Component data as a mapping."""
-        return {
-            field: getattr(self, field) for field in [
-                'firstseen','lastseen','value','trackertype',
-                'hostname'
-            ]
-        }
+    
+    def _get_dict_fields(self):
+        return ['str:firstseen','str:lastseen','value','trackertype','hostname']
     
     @property
     def value(self):

--- a/passivetotal/libs/artifacts.py
+++ b/passivetotal/libs/artifacts.py
@@ -60,6 +60,25 @@ class ArtifactsRequest(Client):
         data.update(kwargs)
         return self._send_data('PUT', 'artifact', 'bulk', data)
     
+    def upsert_artifact(self, project_guid, artifact, artifact_type=None, tags=None, monitor=None):
+        """Update a matching artifact or create it if it does not exist.
+
+        :param project_guid: Unique ID of the project containing the artifact
+        :param artifact: String of the artifact
+        :param type: Type of the artifact, optional (will be inferred if none provided)
+        :param monitor: Whether to monitor the artifact (true or false), optional
+        """
+        results = self.get_artifacts(project=project_guid, query=artifact, type=artifact_type)
+        if 'artifacts' in results: # API returned a list of more than one result
+            raise Exception('More than one artifact matched your search.')
+        if 'guid' in results: # API found one result
+            artifact = results
+        else: # API found no results
+            artifact = self.create_artifact(project_guid=project_guid, artifact=artifact, type=artifact_type, tags=None)
+        if tags is not None or monitor is not None:
+            artifact = self.update_artifact(artifact['guid'], monitor=monitor, tags=tags)
+        return artifact
+
     def update_artifact(self, artifact_guid, **kwargs):
         """Update an existing artifact.
 

--- a/passivetotal/libs/projects.py
+++ b/passivetotal/libs/projects.py
@@ -20,7 +20,7 @@ class ProjectsRequest(Client):
         return len(pattern.findall(test))==1
     
     def find_projects(self, name_or_guid, visibility='analyst', owner=None, creator=None, org=None):
-        """Obtain a list of all projects and find the one project that match the other criteria.
+        """Obtain a list of all projects and find any project that match the criteria.
 
         Set owner='me' or creator='me' to use the API username.
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setup(
     name='passivetotal',
-    version='2.4.0',
+    version='2.4.1',
     description='Library for the RiskIQ PassiveTotal and Illuminate API',
     url="https://github.com/passivetotal/python_api",
     author="RiskIQ",

--- a/sphinx/analyzer.rst
+++ b/sphinx/analyzer.rst
@@ -317,3 +317,23 @@ Malware Lists
 .. autoclass:: passivetotal.analyzer.enrich.MalwareRecord
     :members:
     :inherited-members:
+
+Project Lists
+^^^^^^^^^^^^^^
+    .. autoclass:: passivetotal.analyzer.projects.ProjectList
+        :members:
+        :inherited-members:
+    
+    .. autoclass:: passivetotal.analyzer.projects.Project
+        :members:
+        :inherited-members:
+
+Artifact Lists
+^^^^^^^^^^^^^^
+    .. autoclass:: passivetotal.analyzer.projects.ArtifactList
+        :members:
+        :inherited-members:
+    
+    .. autoclass:: passivetotal.analyzer.projects.Artifact
+        :members:
+        :inherited-members:


### PR DESCRIPTION
## v2.4.1

#### Enhancements:

- Added an `as_dict` property across all Analyzer objects to simplify integration
  with other systems. Returns a dictionary representation of the object or the list.
- New `projects` attribute on IPAddress and Hostname objects returns list of projects
  that contain that host as an artifact. 
- New `analyzer.set_project()` method on the Analyzer module to set an active project
  by name or guid, and new `add_to_project()` methods on Analyzer objects to quickly
  add the object to the active project.
- Direct methods on new `Project` and `Artifact` objects to directly manipulate monitoring
  status and tags.


#### Bug Fixes:

- Added missing ArtifactsRequest to package-level imports