### PR TITLE
include docs in source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include CHANGELOG.md
+graft docs
+graft examples
+graft sphinx


### PR DESCRIPTION
Includes the docs (docs/, sphinx/, examples/, and most important CHANGELOG.md) in the source tarball. When the packages is redistributed (in my case for openSUSE, but affects other distros as well), the docs are directly available for the user and the version changes can easily be extracted from the tarball.