### PR TITLE
Mock requests & recent articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v2.5.3
+
+#### Enhancements
+
+- Better support for unit tests in client libraries with ability to set a 
+  session to override default request methods.
+- Add flexibility to library class instantiation to prefer keyword parameters
+  over config file keys. 
+- Support for new `create_date` Articles API data field and query parameter. Enables
+  searching for most recent articles instead of returning all of them at once, and
+  provides visiblity to situations where an article published in the past was recently
+  added to the Articles collection. 
+
+
+#### Breaking Changes
+
+- Previously, calls to `analyzer.AllArticles()` would return all articles without a date
+  limit. Now, it will return only articles created after the starting date set with
+  `analyzer.set_date_range()`. The current module-level default for all date-bounded queries
+  is 90 days back, so now this function will return all articles created in the last 90 days.
+- `age` property of an Article analyzer object is now based on `create_date` instead of publish
+  date.
+
+
+#### Bug Fixes
+
+[ none ]
+
+
+
 ## v2.5.2
 
 #### Enhancements

--- a/passivetotal/_version.py
+++ b/passivetotal/_version.py
@@ -1,1 +1,1 @@
-VERSION="2.5.2"
+VERSION="2.5.3"

--- a/passivetotal/analyzer/__init__.py
+++ b/passivetotal/analyzer/__init__.py
@@ -56,7 +56,7 @@ def init(**kwargs):
         if 'username' in kwargs and 'api_key' in kwargs:
             api_clients[name] = c(**kwargs)
         else:
-            api_clients[name] = c.from_config()
+            api_clients[name] = c.from_config(**kwargs)
         api_clients[name].exception_class = AnalyzerAPIError
         api_clients[name].set_context('python','passivetotal',VERSION,'analyzer')
     config['is_ready'] = True

--- a/passivetotal/analyzer/_common.py
+++ b/passivetotal/analyzer/_common.py
@@ -429,7 +429,13 @@ class AnalyzerAPIError(AnalyzerError):
             self.json = self.response.json()
         except Exception:
             self.json = {}
-        self.message = self.json.get('error', self.json.get('message', str(response)))
+        if self.json is None:
+            self.message = 'No JSON data in API response'
+        else:
+            try:
+                self.message = self.json.get('error', self.json.get('message', str(response)))
+            except Exception:
+                self.message = ''
     
     def __str__(self):
         return 'Error #{0.status_code} "{0.message}" ({0.url})'.format(self)


### PR DESCRIPTION
## v2.5.3

#### Enhancements

- Better support for unit tests in client libraries with ability to set a 
  session to override default request methods.
- Add flexibility to library class instantiation to prefer keyword parameters
  over config file keys. 
- Support for new `create_date` Articles API data field and query parameter. Enables
  searching for most recent articles instead of returning all of them at once, and
  provides visiblity to situations where an article published in the past was recently
  added to the Articles collection. 


#### Breaking Changes

- Previously, calls to `analyzer.AllArticles()` would return all articles without a date
  limit. Now, it will return only articles created after the starting date set with
  `analyzer.set_date_range()`. The current module-level default for all date-bounded queries
  is 90 days back, so now this function will return all articles created in the last 90 days.
- `age` property of an Article analyzer object is now based on `create_date` instead of publish
  date.


#### Bug Fixes

[ none ]