### PR TITLE
Bugfix lru_cache and dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v2.5.6
+
+#### Bug fixes
+
+- Fixed issue that broke Illuminate ASI and Vuln Intel analyzer modules in Python 3.7 and 
+  earlier due to a missing param on the lru_cache decorator required in those versions.
+- Fixed default end date behavior in analyzer to include a full day rather than stopping at
+  midnight "today". Was causing records with a last-seen date equal to the current date
+  to be excluded from analyzer record list objects (including pDNS, certificates, and 
+  anything else that supported date-bounded queries).
+
+  
+
 ## v2.5.5
 
 #### Enhancements

--- a/passivetotal/_version.py
+++ b/passivetotal/_version.py
@@ -1,1 +1,1 @@
-VERSION="2.5.5"
+VERSION="2.5.6"

--- a/passivetotal/analyzer/__init__.py
+++ b/passivetotal/analyzer/__init__.py
@@ -48,7 +48,6 @@ def init(**kwargs):
         (SslRequest, 'SSL'), 
         (WhoisRequest, 'Whois'),
         (IlluminateRequest, 'Illuminate'),
-        (ArticlesRequest, 'Articles'),
         (ProjectsRequest, 'Projects'),
         (ArtifactsRequest, 'Artifacts'),
         (MonitorRequest, 'Monitor'),
@@ -141,7 +140,7 @@ def set_date_range(days_back=DEFAULT_DAYS_BACK, start=None, start_date=None, end
         now = datetime.now(timezone.utc)
         past = now - timedelta(days=days_back)
         config['start_date'] = past.date().isoformat() + ' 00:00:00'
-        config['end_date'] = now.date().isoformat() + ' 00:00:00'
+        config['end_date'] = now.date().isoformat() + ' 23:59:59'
 
 def set_pdns_timeout(timeout):
     """Set a timeout on pDNS queries to third-party sources."""

--- a/passivetotal/analyzer/illuminate/asi.py
+++ b/passivetotal/analyzer/illuminate/asi.py
@@ -62,7 +62,7 @@ class AttackSurfaces(RecordList, PagedRecordList, ForPandas):
             self._records.append(AttackSurface(api_response=result))
     
     @staticmethod
-    @lru_cache
+    @lru_cache(maxsize=None)
     def load(pagesize=INDICATOR_PAGE_SIZE):
         """Get a list of all third-party (vendor) attack surfaces authorized for this API account.
         

--- a/passivetotal/analyzer/illuminate/vuln.py
+++ b/passivetotal/analyzer/illuminate/vuln.py
@@ -627,7 +627,7 @@ class VulnArticle(Record, ForPandas):
         return self._components
     
     @property
-    @lru_cache
+    @lru_cache(maxsize=None)
     def attack_surfaces(self):
         """List of Illuminate Attack Surfaces (aka third-party vendors) with assets impacted by this vulnerability.
         


### PR DESCRIPTION
- Fixed issue that broke Illuminate ASI and Vuln Intel analyzer modules in Python 3.7 and 
  earlier due to a missing param on the lru_cache decorator required in those versions.
- Fixed default end date behavior in analyzer to include a full day rather than stopping at
  midnight "today". Was causing records with a last-seen date equal to the current date
  to be excluded from analyzer record list objects (including pDNS, certificates, and 
  anything else that supported date-bounded queries).