### PR TITLE
Use name field for SSL certificate searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 
+## v2.5.8
+
+#### Enhancements
+
+- `certificates` property of `analyzer.Hostname` objects now returns same list of SSL
+certificates as the UI, enabled by a CertificateField search with the field set to
+`name`. This activates special-case functionality in the API that performs a
+substring search for a hostname across both subjectAlternativeNames and subjectCommonName fields 
+The previous version only looked at the `subjectAlternativeNames` field. A more narrow
+search across specific fields is still available by instantiating an
+`analyzer.CertificateField` object directly.
+- Docs now show current version number and link to this changelog hosted on GitHub.
+
+
+
 ## v2.5.7
 
 #### Enhancements

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,11 @@ RiskIQ PassiveTotal API.
 
 Learn more at `community.riskiq.com <https://community.riskiq.com>`_
 
+Current Version: |release|
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+`View the changelog <https://github.com/passivetotal/python_api/blob/master/CHANGELOG.md>`_
+on the GitHub project page.
+
 Contents:
 
 .. toctree::

--- a/passivetotal/_version.py
+++ b/passivetotal/_version.py
@@ -1,1 +1,1 @@
-VERSION="2.5.7"
+VERSION="2.5.8"

--- a/passivetotal/analyzer/hostname.py
+++ b/passivetotal/analyzer/hostname.py
@@ -180,7 +180,7 @@ class Hostname(HasComponents, HasCookies, HasTrackers, HasHostpairs,
 
         :rtype: :class:`passivetotal.analyzer.ssl.Certificates`
         """
-        return CertificateField('subjectAlternativeName', self._hostname).certificates
+        return CertificateField('name', self._hostname).certificates
    
     @property
     def whois(self):

--- a/passivetotal/analyzer/pdns.py
+++ b/passivetotal/analyzer/pdns.py
@@ -266,9 +266,9 @@ class HasResolutions:
         
         Provides a list of 
         :class:`passivetotal.analyzer.pdns.PdnsRecord` objects contained in a
-        :class:`passivetotal.analyzer.pdns.PdnsRecords` object.
+        :class:`passivetotal.analyzer.pdns.PdnsResolutions` object.
         
-        :rtype:`passivetotal.analyzer.pdns.PdnsRecords`
+        :rtype: :class:`passivetotal.analyzer.pdns.PdnsResolutions`
         """
         if getattr(self, '_resolutions', None) is not None:
             return self._resolutions

--- a/passivetotal/analyzer/pdns.py
+++ b/passivetotal/analyzer/pdns.py
@@ -6,7 +6,11 @@ from passivetotal.analyzer._common import RecordList, Record, FirstLastSeen, For
 
 class PdnsResolutions(RecordList, ForPandas):
 
-    """Historical passive DNS resolution records."""
+    """Historical passive DNS resolution records.
+    
+    Provides a list-like interface to a collection of
+    :class:`PdnsRecord` objects.
+    """
 
     def __init__(self, api_response = None, query=None):
         super().__init__(api_response, query)
@@ -260,7 +264,11 @@ class HasResolutions:
         Bounded by dates set in :meth:`passivetotal.analyzer.set_date_range`.
         `timeout` and `sources` params are also set by the analyzer configuration.
         
-        Provides list of :class:`passivetotal.analyzer.pdns.PdnsRecord` objects.
+        Provides a list of 
+        :class:`passivetotal.analyzer.pdns.PdnsRecord` objects contained in a
+        :class:`passivetotal.analyzer.pdns.PdnsRecords` object.
+        
+        :rtype:`passivetotal.analyzer.pdns.PdnsRecords`
         """
         if getattr(self, '_resolutions', None) is not None:
             return self._resolutions

--- a/passivetotal/common/const.py
+++ b/passivetotal/common/const.py
@@ -20,7 +20,8 @@ SSL_VALID_FIELDS = ["issuerSurname", "subjectOrganizationName",
                     "subjectLocalityName", "issuerStreetAddress",
                     "issuerLocalityName", "subjectGivenName",
                     "subjectProvince", "issuerSerialNumber",
-                    "issuerEmailAddress","subjectAlternativeName"]
+                    "issuerEmailAddress","subjectAlternativeName",
+                    "name"]
 
 
 ATTRIBUTE_APPROVED_FIELDS = [


### PR DESCRIPTION
## v2.5.8

#### Enhancements

- `certificates` property of `analyzer.Hostname` objects now returns same list of SSL
certificates as the UI, enabled by a CertificateField search with the field set to
`name`. This activates special-case functionality in the API that performs a
substring search for a hostname across both subjectAlternativeNames and subjectCommonName fields 
The previous version only looked at the `subjectAlternativeNames` field. A more narrow
search across specific fields is still available by instantiating an
`analyzer.CertificateField` object directly.
- Docs now show current version number and link to this changelog hosted on GitHub.