### PR TITLE
ASI and vuln doc updates and bug fixes, plus whois history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ libpassivetotal.egg-info/
 pip-wheel-metadata
 docs/_build
 *.vscode
+!.readthedocs.yaml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+
+version: 2
+
+sphinx:
+   configuration: docs/conf.py
+
+python:
+   version: 3.7
+   install:
+     - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,5 +6,6 @@ sphinx:
 
 python:
    version: 3.7
+   setup_py_install: true
    install:
      - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,6 @@ sphinx:
 
 python:
    version: 3.7
-   setup_py_install: true
    install:
+     - requirements: requirements.txt
      - requirements: docs/requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ when methods returned RecordList-type objects.
 to historical Whois (ownership) records. Includes more consistent implementation of
 RecordList functionality and better pandas dataframe support for both historical Whois and 
 field-level Whois searches. 
+- New `impacted_attack_surfaces` property of vulnerability articles (`VulnArticle`) filters 
+the list of third-party vendors to only those with at least one observation. The Illuminate 
+API returns all attack surfaces associated with an API key regardless of whether they are 
+impacted; the complete list is still available in the `attack_surfaces` property. Also updated
+the `info` view of the Pandas dataframe on a vulnerability article so the `impacts` column
+shows the count of impacted attack surfaces.
 
 
 #### Bug Fixes
@@ -24,6 +30,9 @@ field-level Whois searches.
 record list were only counting high-priority insights. 
 - Fixed issue that caused an exception when trying to generate a dictionary view of an
 AttackSurfaceComponent (detection). 
+- Removed reference to non-existant field in `VulnArticle` that was causing an exception when
+rendering a vulnerability article as a dictionary with the `as_dict` property.
+- Handle vuln articles with no impacted assets without raising an exception.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v2.5.9
+
+#### Enhancements
+
+- Significant improvements to the Attack Surface Intelligence (ASI) documentation. Added
+class references for ASI, CTI and vulnerability intelligence to ensure the docs and links
+generated properly. Introduced a new Sphinx module to help generate inline table-of-contents
+for complex classes. Corrected typos in docstrings and ensured consistent type references
+when methods returned RecordList-type objects.
+- Implemented new config files for readthedocs to align with current documentation practices.
+- New `whois_history` property of `Hostname` and `IPAddress` entities gives direct access
+to historical Whois (ownership) records. Includes more consistent implementation of
+RecordList functionality and better pandas dataframe support for both historical Whois and 
+field-level Whois searches. 
+
+
+#### Bug Fixes
+
+- Correctly sum insight and observation counts when accessing Attack Surface Insights
+(ASIs) across multiple severity levels. Previously the `active_insight_count`, 
+`total_insight_count`, and `total_observations` properties of the `all_active_insights`
+record list were only counting high-priority insights. 
+- Fixed issue that caused an exception when trying to generate a dictionary view of an
+AttackSurfaceComponent (detection). 
+
+
 
 ## v2.5.8
 

--- a/docs/analyzer.rst
+++ b/docs/analyzer.rst
@@ -72,8 +72,8 @@ IP Analysis
    :inherited-members:
 
 
-Module Reference
-----------------
+Analyzer Module Reference
+-------------------------
 .. automodule:: passivetotal.analyzer
     :members:
    
@@ -98,6 +98,8 @@ directly inform security research and may guide subsequent searches.
 
 Whois Records
 -------------
+Domain Name Whois
+^^^^^^^^^^^^^^^^^
 The `whois` property for host names returns the DomainWhois record for
 the registered domain name portion of the host name. 
 
@@ -113,7 +115,50 @@ the API tries to normalize and parse the data into fields, your code should alwa
 prepared for missing or malformed data. Access the `raw` record for the API response 
 directly as a Python dict or use the `record` property to get the raw Whois response.
 
-The RiskIQ PassiveTotal API can  search Whois records by field to find related
+IP Whois Records
+^^^^^^^^^^^^^^^^
+The `whois` property is also available for IP addresses. Some of the fields are different
+than domain whois records, but most are the same.
+
+.. code-block:: python
+
+   >>> from passivetotal import analyzer
+   >>> analyzer.init()
+   >>> print(analyzer.IPAddress('160.69.1.37').whois.organization)
+   PACCAR, Inc.
+
+
+Using Whois Fields
+^^^^^^^^^^^^^^^^^^
+Fields in the IP and Hostname Whois record are returned as `WhoisField` objects to faciliate
+field-level searching. Cast the field as a string if you need to get the actual value:
+
+.. code-block:: python
+ 
+   >>> org = analyzer.IPAddress('160.69.1.37').whois.organization
+   >>> org
+   WhoisField('organization','PACCAR, Inc.')
+   >>> print(org)
+   Paccar, Inc.
+   >>> org_str = str(org)
+   >>> org_str
+   Paccar, Inc.
+
+You can also start with a field name and a string and search for it directly to find domains
+or IPs associated with a name, email address, or other supported field type. 
+
+.. code-block:: python
+
+   >>> from passivetotal.analyzer.whois import WhoisField
+   >>> WhoisField('email','domains@riskiq.com').records.domains
+   
+
+
+
+
+Search Whois Records
+^^^^^^^^^^^^^^^^^^^^
+The RiskIQ PassiveTotal API can search Whois records by field to find related
 domain names with the same contact information. Use the `records` property of
 supported fields (any property that returns type `WhoisField`).
 
@@ -123,8 +168,62 @@ supported fields (any property that returns type `WhoisField`).
    >>> analyzer.Hostname('riskiq.net').whois.organization.records.domains
    {Hostname('riskiq.com'), Hostname('riskiq.net'), Hostname('riskiqeg.com')}
 
+The `records` property returns the same type of list-like object that other analyzer
+objects return, so you can filter, sort, and convert to pandas DataFrames as needed.
+See below for reference.
+
+
+Historical Whois Records
+^^^^^^^^^^^^^^^^^^^^^^^^
+Historical whois records may be available for domain names and IP addresses. Access the
+`whois_history` property of an `IPAddress` or `Hostname` object to obtain a list of historically
+observed records as a standard analyzer `RecordList`.
+
+
+.. code-block:: python
+
+    >>> from passivetotal import analyzer
+    >>> for record in analyzer.Hostname('passivetotal.org').whois_history:
+            print(record.last_seen, record.registrant_email)
+    2022-02-11 19:16:29.334000-08:00 passivetotal.org-registrant@anonymised.email
+    2021-04-05 09:13:10.330000-07:00 passivetotal.org-registrant@anonymised.email
+    2021-04-04 08:40:41.295000-07:00 passivetotal.org-registrant@anonymised.email
+    2021-04-03 16:25:42.455000-07:00 passivetotal.org-registrant@anonymised.email
+    2021-04-06 08:42:07.273000-07:00 passivetotal.org-registrant@anonymised.email
+    2021-03-04 15:45:41.026000-08:00 passivetotal.org-Registrant@anonymised.email
+    2021-03-03 13:56:05.605000-08:00 passivetotal.org-registrant@anonymised.email
+    2020-10-06 02:41:38.359000-07:00 passivetotal.org-registrant@anonymised.email
+    2020-10-06 14:01:33.575000-07:00 passivetotal.org-registrant@anonymised.email
+    2020-08-21 04:20:43.757000-07:00 passivetotal.org-Registrant@anonymised.email
+    2020-06-20 03:57:01.411000-07:00 abuse@comlaude.com
+    2020-03-16 15:22:46.043000-07:00 abuse@comlaude.com
+    2020-03-17 06:57:02.899000-07:00 abuse@comlaude.com
+    2019-09-29 07:45:02.096000-07:00 domains@riskiq.com
+
+In this example, we accessed only two fields of each record, but the complete Whois record
+remains available. Consider using the `as_dict` or `as_df` properties of the `whois_history`
+object to get the complete list as a Python dictionary or a Pandas dataframe.
+
+.. code-block:: python
+
+    >>> analyzer.Hostname('passivetotal.org').whois_history.as_dict
+    {'records': [{'admin': {'email': 'passivetotal.org-admin@anonymised.email'},
+    'billing': {},
+    'registrant': {'country': 'US',
+        'email': 'passivetotal.org-registrant@anonymised.email',
+    ...
+
+
+
+Whois Object Reference
+^^^^^^^^^^^^^^^^^^^^^^
+
 
 .. autoclass:: passivetotal.analyzer.whois.DomainWhois
+   :members:
+   :inherited-members:
+
+.. autoclass:: passivetotal.analyzer.whois.IPWhois
    :members:
    :inherited-members:
 
@@ -135,6 +234,18 @@ supported fields (any property that returns type `WhoisField`).
 .. autoclass:: passivetotal.analyzer.whois.WhoisContact
    :members:
    :inherited-members:
+
+.. autoclass:: passivetotal.analyzer.whois.HistoricalWhoisRecords
+    :members:
+    :inherited-members:
+
+.. autoclass:: passivetotal.analyzer.whois.HistoricalDomainWhois
+    :members:
+    :inherited-members:
+
+.. autoclass:: passivetotal.analyzer.whois.HistoricalIPWhois
+    :members:
+    :inherited-members:
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -301,7 +301,9 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 import os
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
+if on_rtd:
+    html_theme = 'default'
+else:
     import sphinx_rtd_theme
     html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,10 +31,17 @@ sys.path.insert(0, os.path.abspath('..'))
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.ifconfig',
+    'autoclasstoc',
+]
+
+autoclasstoc_sections = [
+    'public-attrs',
+    'public-methods',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/illuminate.rst
+++ b/docs/illuminate.rst
@@ -189,7 +189,7 @@ Observations are available in the `observations` property of an AttackSurfaceIns
 
     >>> insights = my_asi.medium_priority_insights.only_active_insights
     >>> first_insight = insights[0]
-    >>> for observation in first_insight:
+    >>> for observation in first_insight.observations:
             print(observation.type)
             print(observation.name)
     HOST
@@ -289,31 +289,52 @@ Examples & Notebooks
 ASI Reference
 ^^^^^^^^^^^^^
 
+.. autosummary::
+    :nosignatures:
+
+    passivetotal.analyzer.illuminate.asi.AttackSurfaces
+    passivetotal.analyzer.illuminate.asi.AttackSurface
+    passivetotal.analyzer.illuminate.asi.AttackSurfaceInsights
+    passivetotal.analyzer.illuminate.asi.AttackSurfaceInsight
+    passivetotal.analyzer.illuminate.asi.AttackSurfaceObservations
+    passivetotal.analyzer.illuminate.asi.AttackSurfaceObservation
+
 .. autoclass:: passivetotal.analyzer.illuminate.asi.AttackSurfaces
     :members:
     :inherited-members:
 
+    .. autoclasstoc::
+
 .. autoclass:: passivetotal.analyzer.illuminate.asi.AttackSurface
     :members:
     :inherited-members:
+
+    .. autoclasstoc::
 
 .. autoclass:: passivetotal.analyzer.illuminate.asi.AttackSurfaceInsights
     :members:
     :inherited-members:
 
     .. automethod:: __init__
+    .. autoclasstoc::
 
 .. autoclass:: passivetotal.analyzer.illuminate.asi.AttackSurfaceInsight
     :members:
     :inherited-members:
 
+    .. autoclasstoc::
+
 .. autoclass:: passivetotal.analyzer.illuminate.asi.AttackSurfaceObservations
     :members:
     :inherited-members:
 
+    .. autoclasstoc::
+
 .. autoclass:: passivetotal.analyzer.illuminate.asi.AttackSurfaceObservation
     :members:
     :inherited-members:
+
+    .. autoclasstoc::
 
 
 
@@ -477,23 +498,39 @@ Examples & Notebooks
 CTI Reference
 ^^^^^^^^^^^^^
 
+.. autosummary::
+    :nosignatures:
+
+    passivetotal.analyzer.illuminate.cti.IntelProfiles
+    passivetotal.analyzer.illuminate.cti.IntelProfile
+    passivetotal.analyzer.illuminate.cti.IntelProfileIndicatorList
+    passivetotal.analyzer.illuminate.cti.IntelProfileIndicator
+
+
 .. autoclass:: passivetotal.analyzer.illuminate.cti.IntelProfiles
     :members:
     :inherited-members:
 
+    .. autoclasstoc::
+
 .. autoclass:: passivetotal.analyzer.illuminate.cti.IntelProfile
     :members:
     :inherited-members: tuple
+
+    .. autoclasstoc::
 
 .. autoclass:: passivetotal.analyzer.illuminate.cti.IntelProfileIndicatorList
     :members:
     :inherited-members:
 
     .. automethod:: __init__
+    .. autoclasstoc::
 
 .. autoclass:: passivetotal.analyzer.illuminate.cti.IntelProfileIndicator
     :members:
     :inherited-members:
+
+    .. autoclasstoc::
 
 
 
@@ -614,30 +651,69 @@ and third-party attack surfaces.
 Vuln Reference
 ^^^^^^^^^^^^^^
 
+.. autosummary::
+    :nosignatures:
+
+    passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVEs
+    passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVE
+    passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVEObservations
+    passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVEObservation
+    passivetotal.analyzer.illuminate.vuln.AttackSurfaceComponents
+    passivetotal.analyzer.illuminate.vuln.AttackSurfaceComponent
+    passivetotal.analyzer.illuminate.vuln.VulnArticle
+    passivetotal.analyzer.illuminate.vuln.VulnArticleImpacts
+    passivetotal.analyzer.illuminate.vuln.VulnArticleImpact
+
 .. autoclass:: passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVEs
     :members:
     :inherited-members:
+
+    .. autoclasstoc::
 
 .. autoclass:: passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVE
     :members:
     :inherited-members:
 
+    .. autoclasstoc::
+
 .. autoclass:: passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVEObservations
     :members:
     :inherited-members:
+
+    .. autoclasstoc::
 
 .. autoclass:: passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVEObservation
     :members:
     :inherited-members:
 
-.. autoclass:: passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVEComponents
+    .. autoclasstoc::
+
+.. autoclass:: passivetotal.analyzer.illuminate.vuln.AttackSurfaceComponents
     :members:
     :inherited-members:
 
-.. autoclass:: passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVEComponent
+    .. autoclasstoc::
+
+.. autoclass:: passivetotal.analyzer.illuminate.vuln.AttackSurfaceComponent
     :members:
     :inherited-members:
+
+    .. autoclasstoc::
 
 .. autoclass:: passivetotal.analyzer.illuminate.vuln.VulnArticle
     :members:
     :inherited-members:
+
+    .. autoclasstoc::
+
+.. autoclass:: passivetotal.analyzer.illuminate.vuln.VulnArticleImpacts
+    :members:
+    :inherited-members:
+
+    .. autoclasstoc::
+
+.. autoclass:: passivetotal.analyzer.illuminate.vuln.VulnArticleImpact
+    :members:
+    :inherited-members:
+
+    .. autoclasstoc::

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+autoclasstoc==1.3.0

--- a/passivetotal/_version.py
+++ b/passivetotal/_version.py
@@ -1,1 +1,1 @@
-VERSION="2.5.8"
+VERSION="2.5.9"

--- a/passivetotal/analyzer/_common.py
+++ b/passivetotal/analyzer/_common.py
@@ -96,7 +96,7 @@ class ForPandas:
     def as_df(self):
         """Get this object as a Pandas DataFrame.
 
-        Use `to_dataframe()' instead if you need to control how the dataframe is built.
+        Use `to_dataframe()` instead if you need to control how the dataframe is built.
 
         Requires the pandas Python library. Throws `AnalyzerError` if it is missing.
         :rtype: :class:`pandas.DataFrame`

--- a/passivetotal/analyzer/hostname.py
+++ b/passivetotal/analyzer/hostname.py
@@ -6,7 +6,7 @@ from passivetotal.analyzer import get_api, get_object
 from passivetotal.analyzer._common import is_ip, refang, AnalyzerError
 from passivetotal.analyzer.pdns import HasResolutions
 from passivetotal.analyzer.summary import HostnameSummary, HasSummary
-from passivetotal.analyzer.whois import DomainWhois
+from passivetotal.analyzer.whois import DomainWhois, HistoricalDomainWhoisRecords
 from passivetotal.analyzer.ssl import CertificateField
 from passivetotal.analyzer.hostpairs import HasHostpairs
 from passivetotal.analyzer.cookies import HasCookies
@@ -95,6 +95,13 @@ class Hostname(HasComponents, HasCookies, HasTrackers, HasHostpairs,
         response = get_api('Whois').get_whois_details(query=self._hostname, compact_record=compact)
         self._whois = DomainWhois(response)
         return self._whois
+    
+    def _api_get_whois_history(self):
+        """Query the Whois API for historical records on this hostname."""
+        response = get_api('Whois').get_whois_details(query=self._hostname, compact_record=False, history=True)
+        self._whois_history = HistoricalDomainWhoisRecords()
+        self._whois_history.parse(response)
+        return self._whois_history
     
     def _query_dns(self):
         """Perform a DNS lookup."""
@@ -193,6 +200,16 @@ class Hostname(HasComponents, HasCookies, HasTrackers, HasHostpairs,
         return self._api_get_whois(
             compact=False
         )
+    
+    @property
+    def whois_history(self):
+        """Historical Whois records for this hostname.
+        
+        :rtype: :class:`passivetotal.analyzer.whois.HistoricalDomainWhoisRecords`
+        """
+        if getattr(self, '_whois_history', None) is not None:
+            return self._whois_history
+        return self._api_get_whois_history()
     
     @property
     def is_ip(self):

--- a/passivetotal/analyzer/hostname.py
+++ b/passivetotal/analyzer/hostname.py
@@ -6,7 +6,7 @@ from passivetotal.analyzer import get_api, get_object
 from passivetotal.analyzer._common import is_ip, refang, AnalyzerError
 from passivetotal.analyzer.pdns import HasResolutions
 from passivetotal.analyzer.summary import HostnameSummary, HasSummary
-from passivetotal.analyzer.whois import DomainWhois, HistoricalDomainWhoisRecords
+from passivetotal.analyzer.whois import DomainWhois, HistoricalWhoisRecords
 from passivetotal.analyzer.ssl import CertificateField
 from passivetotal.analyzer.hostpairs import HasHostpairs
 from passivetotal.analyzer.cookies import HasCookies
@@ -99,7 +99,7 @@ class Hostname(HasComponents, HasCookies, HasTrackers, HasHostpairs,
     def _api_get_whois_history(self):
         """Query the Whois API for historical records on this hostname."""
         response = get_api('Whois').get_whois_details(query=self._hostname, compact_record=False, history=True)
-        self._whois_history = HistoricalDomainWhoisRecords()
+        self._whois_history = HistoricalWhoisRecords()
         self._whois_history.parse(response)
         return self._whois_history
     
@@ -205,7 +205,7 @@ class Hostname(HasComponents, HasCookies, HasTrackers, HasHostpairs,
     def whois_history(self):
         """Historical Whois records for this hostname.
         
-        :rtype: :class:`passivetotal.analyzer.whois.HistoricalDomainWhoisRecords`
+        :rtype: :class:`passivetotal.analyzer.whois.HistoricalWhoisRecords`
         """
         if getattr(self, '_whois_history', None) is not None:
             return self._whois_history

--- a/passivetotal/analyzer/illuminate/asi.py
+++ b/passivetotal/analyzer/illuminate/asi.py
@@ -17,7 +17,8 @@ INDICATOR_PAGE_SIZE = 400
 
 class AttackSurfaces(RecordList, PagedRecordList, ForPandas):
 
-    """List of RiskIQ Illuminate Attack Surfaces.
+    """Collection of RiskIQ Illuminate Attack Surfaces in a list-like object
+    containing :class:`AttackSurface` objects.
     
     Primarily used for enumerating a set of third-party vendors.
     """
@@ -157,7 +158,7 @@ class AttackSurface(Record, ForPandas):
         """Get insights at a level (high, medium or low).
         
         :param level: Priority level (high, medium, or low).
-        :returns: List of :class:`AttackSurfaceInsights`
+        :returns: :class:`AttackSurfaceInsights`
         """
         self._ensure_valid_level(level)
         if self._insights[level] is not None:
@@ -178,6 +179,7 @@ class AttackSurface(Record, ForPandas):
         """Get a list of CVEs impacting assets in this attack surface.
         
         :param pagesize: Size of pages to retrieve from the API.
+        :rtype: :class:`passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVEs`
         """
         from passivetotal.analyzer.illuminate import AttackSurfaceCVEs
         self._cves = AttackSurfaceCVEs(self, pagesize)
@@ -188,6 +190,8 @@ class AttackSurface(Record, ForPandas):
         """Get a list of vulnerable components (detections) in this attack surface.
         
         :param pagesize: Size of pages to retrieve from the API.
+
+        :rtype: :class:`passivetotal.analyzer.illuminate.vuln.AttackSurfaceComponents`
         """
         from passivetotal.analyzer.illuminate import AttackSurfaceComponents
         self._components = AttackSurfaceComponents(self, pagesize)
@@ -266,7 +270,7 @@ class AttackSurface(Record, ForPandas):
     def high_priority_insights(self):
         """Get high priority insights.
         
-        :rtype: List of :class:`passivetotal.analyzer.illuminate.asi.AttackSurfaceInsights`
+        :rtype: :class:`passivetotal.analyzer.illuminate.asi.AttackSurfaceInsights`
         """
         return self.get_insights('high')
     
@@ -274,7 +278,7 @@ class AttackSurface(Record, ForPandas):
     def medium_priority_insights(self):
         """Get medium priority insights.
         
-        :rtype: List of :class:`passivetotal.analyzer.illuminate.asi.AttackSurfaceInsights`
+        :rtype: :class:`passivetotal.analyzer.illuminate.asi.AttackSurfaceInsights`
         """
         return self.get_insights('medium')
     
@@ -282,7 +286,7 @@ class AttackSurface(Record, ForPandas):
     def low_priority_insights(self):
         """Get low priority insights.
         
-        :rtype: List of :class:`passivetotal.analyzer.illuminate.asi.AttackSurfaceInsights`
+        :rtype: :class:`passivetotal.analyzer.illuminate.asi.AttackSurfaceInsights`
         """
         return self.get_insights('low')
     
@@ -290,7 +294,7 @@ class AttackSurface(Record, ForPandas):
     def cves(self):
         """Get a list of CVEs associated with this attack surface.
         
-        :rtype: List of :class:`passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVE`
+        :rtype: :class:`passivetotal.analyzer.illuminate.vuln.AttackSurfaceCVEs`
         """
         if getattr(self, '_cves', None) is not None:
             return self._cves
@@ -298,7 +302,10 @@ class AttackSurface(Record, ForPandas):
 
     @property
     def components(self):
-        """List of components (detections) vulnerable to this CVE in this attack surface."""
+        """List of components (detections) vulnerable to this CVE in this attack surface.
+        
+        :rtype: :class:`passivetotal.analyzer.illuminate.vuln.AttackSurfaceComponents`
+        """
         if getattr(self, '_components', None) is not None:
             return self._components
         return self.get_components()
@@ -306,7 +313,8 @@ class AttackSurface(Record, ForPandas):
 
 class AttackSurfaceInsights(RecordList, ForPandas):
 
-    """List of insights associated with an attack surface."""
+    """Collection of insights associated with an attack surface in a list-like object
+    containing :class:`AttackSurfaceInsight` objects."""
 
     def __init__(self, attack_surface=None, level=None, api_response=None):
         self._attack_surface = attack_surface
@@ -363,7 +371,7 @@ class AttackSurfaceInsights(RecordList, ForPandas):
     def only_active_insights(self):
         """Filter to only active insights (insights with active observations).
         
-        :rtype: bool
+        :rtype: :class:`AttackSurfaceInsights`
         """
         return self.filter(has_observations=True)
     
@@ -466,6 +474,7 @@ class AttackSurfaceInsight(Record, ForPandas):
         """Get a list of impacted assets (observations).
         
         :param pagesize: Size of pages to retrieve from the API.
+        :rtype: :class:`AttackSurfaceObservations`
         """
         self._observations = AttackSurfaceObservations(self, self._group_by, self._segment_by)
         self._observations.load_all_pages()
@@ -473,7 +482,10 @@ class AttackSurfaceInsight(Record, ForPandas):
 
     @property
     def observations(self):
-        """List of impacted assets."""
+        """List of impacted assets.
+        
+        :rtype: :class:`AttackSurfaceObservations`
+        """
         if getattr(self, '_observations', None) is not None:
             return self._observations
         return self.get_observations()
@@ -482,7 +494,8 @@ class AttackSurfaceInsight(Record, ForPandas):
 
 class AttackSurfaceObservations(RecordList, PagedRecordList, ForPandas):
 
-    """List of observations (assets) associated with an attack surface insight."""
+    """Collection of observations (assets) associated with an attack surface insight
+    in a list-like object containing :class:`AttackSurfaceObservation` objects."""
 
     def __init__(self, insight, group_by, segment_by, pagesize=400):
         self._totalrecords = None
@@ -548,6 +561,8 @@ class AttackSurfaceObservations(RecordList, PagedRecordList, ForPandas):
 
 
 class AttackSurfaceObservation(Record, FirstLastSeen, ForPandas):
+    """An attack surface asset (typically identified by an IP address or hostname) that
+    is impacted by an observation."""
     
     def __init__(self, insight, api_response):
         self._insight = insight
@@ -579,18 +594,29 @@ class AttackSurfaceObservation(Record, FirstLastSeen, ForPandas):
 
     @property
     def type(self):
+        """Type of impacted asset (i.e. HOST or IP_ADDRESS)."""
         return self._type
     
     @property
     def name(self):
+        """Name of impacted asset (i.e. the IP address or hostname)."""
         return self._name
     
     @property
     def insight(self):
+        """Attack surface insight associated with this observation.
+        
+        :rtype: :class:`AttackSurfaceInsight`
+        """
         return self._insight
     
     @property
     def hostname(self):
+        """Shortcut property to access an `analyzer.Hostname` object from this
+        observation, if the observation type is HOST, else returns `None`.
+        
+        :rtype: :class:`passivetotal.analyzer.Hostname`
+        """
         if self._type != 'HOST':
             return None
         try:
@@ -600,6 +626,11 @@ class AttackSurfaceObservation(Record, FirstLastSeen, ForPandas):
     
     @property
     def ip(self):
+        """Shortcut property to access an `analyzer.IPAddress` object from this
+        observation, if the observation type is IP_ADDRESS, else returns `None`.
+        
+        :rtype: :class:`passivetotal.analyzer.IPAddress`
+        """
         if self._type != 'IP_ADDRESS':
             return None
         try:

--- a/passivetotal/analyzer/illuminate/asi.py
+++ b/passivetotal/analyzer/illuminate/asi.py
@@ -218,12 +218,17 @@ class AttackSurface(Record, ForPandas):
         
         :rtype: :class:`passivetotal.analyzer.illuminate.asi.AttackSurfaceInsights`
         """
-        insights = self.high_priority_insights._make_shallow_copy()
-        insights._level = 'ALL'
-        insights._records = []
-        for level in self._LEVELS:
-            insights._records.extend(self.get_insights(level)._records)
-        return insights
+        insights_all = self.high_priority_insights._make_shallow_copy()
+        count_fields = ['_count_active_insights','_count_total_insights','_count_total_observations']
+        for field in count_fields:
+            setattr(insights_all, field, 0)
+        insights_all._level = 'ALL'
+        insights_all._records = []
+        for level in [self.get_insights(level) for level in self._LEVELS]:
+            insights_all._records.extend(level._records)
+            for field in count_fields:
+                setattr(insights_all, field, getattr(insights_all, field) + getattr(level, field))
+        return insights_all
     
     @property
     def all_active_insights(self):
@@ -353,7 +358,7 @@ class AttackSurfaceInsights(RecordList, ForPandas):
     
     @property
     def attack_surface(self):
-        """Attach surface these insights are associated with.
+        """Attack surface these insights are associated with.
         
         :rtype: :class:`passivetotal.analyzer.illuminate.asi.AttackSurface`
         """

--- a/passivetotal/analyzer/illuminate/cti.py
+++ b/passivetotal/analyzer/illuminate/cti.py
@@ -212,7 +212,7 @@ class IntelProfile(Record, ForPandas):
     def indicators(self):
         """Unfiltered indicator list associated with this intel profile.
 
-        Calls `passivetotal.analyzer.illuminate.IntelProfile.get_indicators()'
+        Calls `passivetotal.analyzer.illuminate.IntelProfile.get_indicators()`
         with default parameters. Use that method directly for more granular control.
 
         :rtype: :class:`passivetotal.analyzer.illuminate.cti.IntelProfileIndicatorList`
@@ -245,7 +245,8 @@ class IntelProfile(Record, ForPandas):
 class IntelProfileIndicatorList(RecordList, PagedRecordList, ForPandas):
 
     def __init__(self, profile_id=None, query=None, types=None, categories=None, sources=None, pagesize=INDICATOR_PAGE_SIZE):
-        """List of indicators associated with a RiskIQ Intel Profile.
+        """Collection of indicators associated with a RiskIQ Intel Profile as a list-like object
+        containing :class:`IntelProfileIndicator` objects.
         
         :param profile_id: Threat intel profile ID to search for.
         :param query: Indicator value to query for.

--- a/passivetotal/analyzer/illuminate/vuln.py
+++ b/passivetotal/analyzer/illuminate/vuln.py
@@ -15,7 +15,8 @@ INDICATOR_PAGE_SIZE = 400
     
 class AttackSurfaceCVEs(RecordList, PagedRecordList, ForPandas):
 
-    """List of CVEs associated with an attack surface."""
+    """Collection of CVEs associated with an attack surface as a list-like object
+    containing :class:`AttackSurfaceCVE` objects."""
 
     def __init__(self, attack_surface=None, pagesize=400):
         self._totalrecords = None
@@ -107,6 +108,7 @@ class AttackSurfaceCVE(Record, ForPandas):
         """Get a list of observations(assets) vulnerable to this CVE in this attack surface.
         
         :param pagesize: Size of pages to retrieve from the API.
+        :rtype: :class:`AttackSurfaceCVEObservations`
         """
         self._observations = AttackSurfaceCVEObservations(self, pagesize)
         self._observations.load_all_pages()
@@ -185,7 +187,8 @@ class AttackSurfaceCVE(Record, ForPandas):
 
 class AttackSurfaceCVEObservations(RecordList, PagedRecordList, ForPandas):
 
-    """List of observations (assets) associated with a CVE in a specific attack surface."""
+    """Collection of observations (assets) associated with a CVE in a specific attack surface
+    as a list-like object containing :class:`AttackSurfaceCVEObservation` objects."""
 
     def __init__(self, cve=None, pagesize=400):
         self._totalrecords = None
@@ -309,7 +312,8 @@ class AttackSurfaceCVEObservation(Record, FirstLastSeen, ForPandas):
 
 class AttackSurfaceComponents(RecordList, PagedRecordList, ForPandas):
 
-    """List of vulnerable components (detections) associated with an attack surface."""
+    """Collection of vulnerable components (detections) associated with an attack surface
+    as a list-like object containing :class:`AttackSurfaceComponent` objects."""
 
     def __init__(self, attack_surface=None, pagesize=400):
         self._totalrecords = None
@@ -338,7 +342,7 @@ class AttackSurfaceComponents(RecordList, PagedRecordList, ForPandas):
     
     @property
     def attack_surface(self):
-        """Get the CVE associated with this list of observations.
+        """Get the attack surface associated with this list of observations.
         
         :rtype: :class:`passivetotal.analyzer.illuminate.asi.AttackSurface`
         """
@@ -642,7 +646,10 @@ class VulnArticle(Record, ForPandas):
     
     @property
     def observations(self):
-        """List of observations (assets) within the primary attack surface that are impacted by this vulnerability."""
+        """List of observations (assets) within the primary attack surface that are impacted by this vulnerability.
+        
+        :rtype: :class:`AttackSurfaceCVEObservations`
+        """
         from . import AttackSurface
         attack_surface = AttackSurface.load()
         article = {
@@ -659,7 +666,8 @@ class VulnArticle(Record, ForPandas):
 
 class VulnArticleImpacts(RecordList, ForPandas):
 
-    """List of Illuminate Attack Surfaces impacted by a vulnerability."""
+    """Collection of Illuminate Attack Surfaces impacted by a vulnerability as a list-like
+    object containing :class:`VulnArticleImpact` objects."""
 
     def __init__(self, article=None, impacts=[]):
         self._records = []
@@ -685,7 +693,10 @@ class VulnArticleImpacts(RecordList, ForPandas):
     
     @property
     def article(self):
-        """Article that describes the vulnerability impacting these attack surfaces."""
+        """Article that describes the vulnerability impacting these attack surfaces.
+        
+        :rtype: :class:`VulnArticle`
+        """
         return self._article
     
     @property

--- a/passivetotal/analyzer/illuminate/vuln.py
+++ b/passivetotal/analyzer/illuminate/vuln.py
@@ -381,7 +381,7 @@ class AttackSurfaceComponent(Record, FirstLastSeen, ForPandas):
         return '<AttackSurfaceComponent {0.type}:{0.name}>'.format(self)
     
     def _get_dict_fields(self):
-        return ['vendor_id','type','name','severity','count']
+        return ['type','name','severity','count']
     
     def to_dataframe(self):
         """Render this object as a Pandas dataframe.

--- a/passivetotal/analyzer/ip.py
+++ b/passivetotal/analyzer/ip.py
@@ -3,7 +3,7 @@
 
 from passivetotal.analyzer import get_api, get_config
 from passivetotal.analyzer._common import is_ip, refang, AnalyzerError
-from passivetotal.analyzer.whois import IPWhois
+from passivetotal.analyzer.whois import IPWhois, HistoricalIPWhoisRecords
 from passivetotal.analyzer.pdns import HasResolutions
 from passivetotal.analyzer.services import Services
 from passivetotal.analyzer.ssl import Certificates
@@ -103,10 +103,17 @@ class IPAddress(HasComponents, HasCookies, HasHostpairs, HasTrackers,
         return self._ssl_history
 
     def _api_get_whois(self):
-        """Query the pDNS API for resolution history."""
+        """Query the whois API."""
         response = get_api('Whois').get_whois_details(query=self._ip)
         self._whois = IPWhois(response)
         return self._whois
+    
+    def _api_get_whois_history(self):
+        """Query the whois API for ownership history."""
+        response = get_api('Whois').get_whois_details(query=self._ip, history=True)
+        self._whois_history = HistoricalIPWhoisRecords()
+        self._whois_history.parse(response)
+        return self._whois_history
     
     @property
     def ip(self):
@@ -143,6 +150,16 @@ class IPAddress(HasComponents, HasCookies, HasHostpairs, HasTrackers,
         if getattr(self, '_whois', None) is not None:
             return self._whois
         return self._api_get_whois()
+    
+    @property
+    def whois_history(self):
+        """Historical Whois (ownership) records for this IP.
+
+        :rtype: :class:`passivetotal.analyzer.whois.HistoricalIPWhoisRecords`
+        """
+        if getattr(self, '_whois_history', None) is not None:
+            return self._whois_history
+        return self._api_get_whois_history()
     
     @property
     def is_ip(self):

--- a/passivetotal/analyzer/ip.py
+++ b/passivetotal/analyzer/ip.py
@@ -3,7 +3,7 @@
 
 from passivetotal.analyzer import get_api, get_config
 from passivetotal.analyzer._common import is_ip, refang, AnalyzerError
-from passivetotal.analyzer.whois import IPWhois, HistoricalIPWhoisRecords
+from passivetotal.analyzer.whois import IPWhois, HistoricalWhoisRecords
 from passivetotal.analyzer.pdns import HasResolutions
 from passivetotal.analyzer.services import Services
 from passivetotal.analyzer.ssl import Certificates
@@ -111,7 +111,7 @@ class IPAddress(HasComponents, HasCookies, HasHostpairs, HasTrackers,
     def _api_get_whois_history(self):
         """Query the whois API for ownership history."""
         response = get_api('Whois').get_whois_details(query=self._ip, history=True)
-        self._whois_history = HistoricalIPWhoisRecords()
+        self._whois_history = HistoricalWhoisRecords()
         self._whois_history.parse(response)
         return self._whois_history
     
@@ -155,7 +155,7 @@ class IPAddress(HasComponents, HasCookies, HasHostpairs, HasTrackers,
     def whois_history(self):
         """Historical Whois (ownership) records for this IP.
 
-        :rtype: :class:`passivetotal.analyzer.whois.HistoricalIPWhoisRecords`
+        :rtype: :class:`passivetotal.analyzer.whois.HistoricalWhoisRecords`
         """
         if getattr(self, '_whois_history', None) is not None:
             return self._whois_history

--- a/passivetotal/analyzer/ssl.py
+++ b/passivetotal/analyzer/ssl.py
@@ -44,7 +44,7 @@ class Certificates(RecordList, ForPandas):
     
     @property
     def not_expired(self):
-        """Filtered list of :class:`Certificates' that have not expired."""
+        """Filtered list of :class:`Certificates` that have not expired."""
         return self.filter(expired=False)
 
 

--- a/passivetotal/analyzer/whois.py
+++ b/passivetotal/analyzer/whois.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from collections import namedtuple, OrderedDict
 import pprint
 from passivetotal.analyzer import get_api, get_object
-from passivetotal.analyzer._common import RecordList, ForPandas
+from passivetotal.analyzer._common import Record, RecordList, ForPandas
 
 
 
@@ -44,6 +44,14 @@ class WhoisField:
 
     def __repr__(self):
         return "WhoisField('{0.name}','{0.value}')".format(self)
+    
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self._value == other
+        return other is self
+    
+    def __hash__(self):
+        return self._value.__hash__()
 
     def _api_search(self):
         """Use the 'Whois' request wrapper to perform a keyword search by field."""
@@ -70,7 +78,7 @@ class WhoisField:
 
 
 
-class WhoisRecords(RecordList):
+class WhoisRecords(RecordList, ForPandas):
 
     """List of Whois records."""
 
@@ -103,10 +111,36 @@ class WhoisRecords(RecordList):
     def orgs(self):
         """Return a set of unique org names in this record list."""
         return set([r.organization for r in self if r.organization])
-    
 
 
-class WhoisRecord(ForPandas):
+
+class HistoricalDomainWhoisRecords(WhoisRecords):
+
+    """List of :class:`HistoricalDomainWhois` records."""
+
+    def _get_sortable_fields(self):
+        return ['domain','last_seen']
+
+    def parse(self, api_response):
+        """Parse an API response into a list of `HistoricalDomainWhois` records."""
+        self._records = list(map(HistoricalDomainWhois, api_response.get('results',[])))
+
+
+
+class HistoricalIPWhoisRecords(WhoisRecords):
+
+    """List of :class:`HistoricalIPWhois` records."""
+
+    def _get_sortable_fields(self):
+        return ['ip','last_seen']
+
+    def parse(self, api_response):
+        """Parse an API response into a list of `HistoricalIPWhois` records."""
+        self._records = list(map(HistoricalIPWhois, api_response.get('results',[])))
+       
+
+
+class WhoisRecord(Record, ForPandas):
     """Base type for IP and Domain Whois."""
 
     def _get_contacts(self, contact_type):
@@ -389,6 +423,38 @@ class DomainWhois(WhoisRecord):
 
 
 
+class HistoricalDomainWhois(DomainWhois):
+
+    """Historical Whois record for a domain name."""
+
+    def __new__(cls, record):
+        self = object.__new__(HistoricalDomainWhois)
+        self._domain = record['domain']
+        self._rawrecord = record
+        return self
+    
+    def __str__(self):
+        return '{0.last_seen} registrant: "{0.organization} | {0.registrant_name} | {0.registrant_email}"'.format(self)
+
+    def __repr__(self):
+        return "HistoricalDomainWhois<'{0.domain}' @ '{0.last_seen}'>".format(self)
+    
+    def _dict_for_df(self, **kwargs):
+        as_d = OrderedDict(last_seen=self.last_seen)
+        as_d.update(super()._dict_for_df(**kwargs))
+        return as_d
+    
+    @property
+    def last_seen(self):
+        """Date the historical record was last seen.
+        
+        Alias for `date_loaded`.
+        :rtype: datetime
+        """
+        return self.date_loaded
+
+
+
 class IPWhois(WhoisRecord):
     """Whois record for an IP Address."""
 
@@ -418,3 +484,34 @@ class IPWhois(WhoisRecord):
     def ip(self):
         return get_object(self._domain, type='IPAddress')
 
+
+
+class HistoricalIPWhois(IPWhois):
+
+    """Historical Whois record for a IP address."""
+
+    def __new__(cls, record):
+        self = object.__new__(HistoricalIPWhois)
+        self._domain = record['domain']
+        self._rawrecord = record
+        return self
+    
+    def __str__(self):
+        return '{0.last_seen} registrant: "{0.organization} | {0.registrant_name} | {0.registrant_email}"'.format(self)
+
+    def __repr__(self):
+        return "HistoricalIPWhois<'{0.ip}' @ '{0.last_seen}'>".format(self)
+    
+    def _dict_for_df(self, **kwargs):
+        as_d = OrderedDict(last_seen=self.last_seen)
+        as_d.update(super()._dict_for_df(**kwargs))
+        return as_d
+    
+    @property
+    def last_seen(self):
+        """Date the historical record was last seen.
+        
+        Alias for `date_loaded`.
+        :rtype: datetime
+        """
+        return self.date_loaded


### PR DESCRIPTION
#### Enhancements

- Significant improvements to the Attack Surface Intelligence (ASI) documentation. Added
class references for ASI, CTI and vulnerability intelligence to ensure the docs and links
generated properly. Introduced a new Sphinx module to help generate inline table-of-contents
for complex classes. Corrected typos in docstrings and ensured consistent type references
when methods returned RecordList-type objects.
- Implemented new config files for readthedocs to align with current documentation practices.
- New `whois_history` property of `Hostname` and `IPAddress` entities gives direct access
to historical Whois (ownership) records. Includes more consistent implementation of
RecordList functionality and better pandas dataframe support for both historical Whois and 
field-level Whois searches. Should close #45 
- New `impacted_attack_surfaces` property of vulnerability articles (`VulnArticle`) filters 
the list of third-party vendors to only those with at least one observation. The Illuminate 
API returns all attack surfaces associated with an API key regardless of whether they are 
impacted; the complete list is still available in the `attack_surfaces` property. Also updated
the `info` view of the Pandas dataframe on a vulnerability article so the `impacts` column
shows the count of impacted attack surfaces.

#### Bug Fixes

- Correctly sum insight and observation counts when accessing Attack Surface Insights
(ASIs) across multiple severity levels. Previously the `active_insight_count`, 
`total_insight_count`, and `total_observations` properties of the `all_active_insights`
record list were only counting high-priority insights. 
- Fixed issue that caused an exception when trying to generate a dictionary view of an
AttackSurfaceComponent (detection). 
- Removed reference to non-existant field in `VulnArticle` that was causing an exception when
rendering a vulnerability article as a dictionary with the `as_dict` property.
- Handle vuln articles with no impacted assets without raising an exception.